### PR TITLE
chore: set required uv version in pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          python-version-file: pyproject.toml
 
       - name: Install dev dependencies
         run: uv sync --group dev --frozen
@@ -44,8 +42,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          python-version-file: pyproject.toml
 
       - name: Install dev dependencies
         run: uv sync --group dev --frozen
@@ -77,8 +73,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          python-version-file: pyproject.toml
 
       - name: Install dev dependencies
         run: uv sync --group dev --frozen

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,8 +23,6 @@ jobs:
             libsndfile1
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          python-version-file: pyproject.toml
 
       - name: Install Python dependencies
         run: uv sync --group dev --frozen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,6 @@ jobs:
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v7
-        with:
-          python-version-file: pyproject.toml
 
       - name: Install dev dependencies
         run: uv sync --group dev --frozen

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 FROM python:3.14-slim AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.2@sha256:c4f5de312ee66d46810635ffc5df34a1973ba753e7241ce3a08ef979ddd7bea5 /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
 ]
 
 [tool.uv]
+required-version = "0.11.2"
 package = false
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This pull request makes several updates to the project's CI workflows and Docker setup, primarily to standardize and pin the `uv` Python package manager version across environments. The changes ensure reproducibility and consistency in dependency management both in CI and Docker builds.

**Dependency management and environment consistency:**

* Updated the Dockerfile to explicitly use `uv` version `0.11.2` with a specific image digest, ensuring consistent builds and avoiding unexpected upgrades.
* Added a `required-version = "0.11.2"` setting for `uv` in `pyproject.toml` to enforce the use of this version in local and CI environments.

**CI workflow simplification:**

* Removed the `python-version-file` argument from all uses of `astral-sh/setup-uv@v7` in CI workflow files (`ci.yml`, `copilot-setup-steps.yml`, and `release.yml`), simplifying the setup and relying on the version pinning in `pyproject.toml` and Dockerfile. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL23-L24) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-L48) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL80-L81) [[4]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL26-L27) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-L36)This pull request updates the configuration for the `uv` Python package manager across several CI workflows and the project configuration. The main changes simplify how the Python version is determined and ensure a specific `uv` version is used for consistency.

Dependency management improvements:

* Added a `required-version = 0.11.2` setting for `uv` in `pyproject.toml` to enforce the use of this version in all environments.

CI workflow simplification:

* Removed the `python-version-file: pyproject.toml` option from all usages of `astral-sh/setup-uv@v7` in `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/copilot-setup-steps.yml`, allowing `uv` to determine the Python version automatically. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL47-L48) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L35-L36) [[3]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL26-L27)## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
