### PR TITLE
chore(ci): Remove daily cron schedule from smoke.yml

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,8 +4,6 @@ name: Smoke Tests
 # Builds the Docker image, starts a container, and exercises the full stack
 # including real demucs stem splitting and rubberband audio processing.
 on:
-  schedule:
-    - cron: "0 3 * * *"  # 03:00 UTC every day
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
Removed the daily schedule for the smoke workflow.

## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
