### PR TITLE
Opencode/fix pending display

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -341,12 +341,23 @@ def _process_version_task(song_id: str, pitch: float, tempo: float) -> None:
             raise AudioProcessorError(f"Stem file missing for {song_id}/{stem_name}")
         output_path = storage.processed_path(song_id, stem_name, pitch, tempo)
         if not output_path.exists():
-            processor.process(
-                input_path,
-                output_path,
-                pitch_semitones=pitch,
-                tempo_ratio=tempo,
-            )
+            # Write to a temporary path first, then rename atomically.  This
+            # prevents list_versions / version_status from seeing the file as
+            # present (and potentially READY) while rubberband is still writing
+            # it, which would cause the UI to prematurely drop the pending
+            # indicator on the version bubble.
+            tmp_path = output_path.with_suffix(".tmp")
+            try:
+                processor.process(
+                    input_path,
+                    tmp_path,
+                    pitch_semitones=pitch,
+                    tempo_ratio=tempo,
+                )
+                tmp_path.rename(output_path)
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
 
     futures: dict[concurrent.futures.Future[None], StemName] = {
         process_executor.submit(_process_single_stem, stem): stem
@@ -606,6 +617,13 @@ def _song_router() -> APIRouter:
 
         The default version (pitch=0, tempo=1.0) is always included first and
         represents the unmodified stems produced by demucs.
+
+        Non-default versions are sourced exclusively from versions.json, which
+        is only written by touch_version() *after* all stems have been fully
+        processed and their output files atomically renamed into place.  This
+        means the list never contains an in-progress version, so the frontend
+        pending indicator on a version bubble stays active until the version is
+        truly ready.
         """
         _require_ready_song(song_id)
         pairs = storage.list_versions(song_id)

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -223,25 +223,24 @@ class SongStorage:
         return evicted
 
     def list_versions(self, song_id: str) -> list[tuple[float, float]]:
-        """Return unique (pitch_semitones, tempo_ratio) pairs from processed/ dir."""
-        proc_dir = self.processed_output_dir(song_id)
-        if not proc_dir.exists():
-            return []
+        """Return (pitch_semitones, tempo_ratio) pairs registered in versions.json.
 
-        versions: set[tuple[float, float]] = set()
-        for f in proc_dir.iterdir():
-            if f.suffix != ".mp3":
-                continue
-            name = f.stem  # filename without .mp3
-            for stem in StemName:
-                prefix = f"{stem.value}_"
-                if name.startswith(prefix):
-                    tag = name[len(prefix) :]
-                    parsed = self._parse_version_tag(tag)
-                    if parsed is not None:
-                        versions.add(parsed)
-                    break
+        Only versions that have been fully committed via :meth:`touch_version`
+        are returned.  Files that are still being written (e.g. by a rubberband
+        subprocess) or that were left behind by a crashed process are
+        intentionally excluded – they have no entry in versions.json yet.
 
+        This is the authoritative source of truth for which versions are ready
+        for use.  Combined with atomic temp-file writes in the processing
+        pipeline, it prevents the version bubble in the UI from flickering to
+        "ready" before computation has actually finished.
+        """
+        meta = self.read_version_meta(song_id)
+        versions: list[tuple[float, float]] = []
+        for tag in meta:
+            parsed = self._parse_version_tag(tag)
+            if parsed is not None:
+                versions.append(parsed)
         return sorted(versions)
 
     @staticmethod

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1102,16 +1102,18 @@ class TestListVersions:
         assert default["is_default"] is True
 
     def test_includes_cached_versions(self, client: TestClient, data_dir: Path) -> None:
-        """Processed files in processed/ dir are reflected in response."""
+        """Versions registered in versions.json are reflected in response."""
         import backend.app.main as main_module
 
         self._make_ready_song(data_dir)
         storage = SongStorage(data_dir)
         main_module.storage = storage
-        # Create a processed file
+        # Create all processed files and register via touch_version so
+        # list_versions (which now reads versions.json) picks them up.
         for stem in StemName:
             path = storage.processed_path("ver-song", stem, 2.0, 1.5)
             path.write_bytes(b"\x00" * 10)
+        storage.touch_version("ver-song", 2.0, 1.5)
 
         resp = client.get("/api/songs/ver-song/versions")
         assert resp.status_code == 200
@@ -1126,7 +1128,13 @@ class TestListVersions:
     def test_ignores_duplicate_default_cached_version(
         self, client: TestClient, data_dir: Path
     ) -> None:
-        """A cached 0/1 pair must not appear as a second non-default entry."""
+        """Files for the 0/1 pair must not appear as a second non-default entry.
+
+        list_versions reads from versions.json.  Even if processed files for
+        pitch=0, tempo=1.0 exist on disk, the default version entry in the
+        response is always the hardcoded one inserted by the endpoint, and
+        the skip guard (pitch==0.0 and tempo==1.0) prevents a duplicate.
+        """
         import backend.app.main as main_module
 
         self._make_ready_song(data_dir)
@@ -1135,6 +1143,8 @@ class TestListVersions:
         for stem in StemName:
             path = storage.processed_path("ver-song", stem, 0.0, 1.0)
             path.write_bytes(b"\x00" * 10)
+        # Register the default pair in versions.json to exercise the skip guard.
+        storage.touch_version("ver-song", 0.0, 1.0)
 
         resp = client.get("/api/songs/ver-song/versions")
         assert resp.status_code == 200
@@ -1419,12 +1429,18 @@ class TestListVersionsEnriched:
     def test_partial_version_shows_partial_status(
         self, client: TestClient, data_dir: Path
     ) -> None:
+        """A version registered in versions.json with only some stems shows PARTIAL.
+
+        touch_version registers the pair so list_versions returns it; writing
+        only 1 of 4 stem files makes version_status return PARTIAL.
+        """
         import backend.app.main as main_module
 
         self._make_ready_song(data_dir)
         storage = SongStorage(data_dir)
         main_module.storage = storage
-        # Only 1 of 4 stems cached
+        # Register the version first, then write only 1 of 4 stems.
+        storage.touch_version("lve-song", 1.0, 1.5)
         storage.processed_path("lve-song", StemName.BASS, 1.0, 1.5).write_bytes(b"\x00")
 
         resp = client.get("/api/songs/lve-song/versions")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -174,16 +174,28 @@ class TestVersionStorage:
         assert storage.list_versions(song.id) == []
 
     def test_list_versions_empty_dir(self, storage: SongStorage) -> None:
-        """list_versions returns [] for an existing but empty processed/ dir."""
+        """list_versions returns [] for an existing but empty processed/ dir.
+
+        With the versions.json-based implementation, emptiness of the
+        directory is irrelevant; an absent or empty versions.json also
+        produces [].
+        """
         song = storage.create_song("song.mp3")
         storage.processed_output_dir(song.id).mkdir(parents=True, exist_ok=True)
         assert storage.list_versions(song.id) == []
 
     def test_list_versions_single(self, storage: SongStorage) -> None:
-        """A single processed file yields one version tuple."""
+        """A version registered via touch_version is returned by list_versions.
+
+        list_versions reads from versions.json, so files that exist on disk but
+        have not been committed via touch_version are excluded.
+        """
         song = storage.create_song("song.mp3")
         path = storage.processed_path(song.id, StemName.VOCALS, 2.0, 1.5)
         path.write_bytes(b"\x00" * 10)
+        # Version is not visible until registered.
+        assert storage.list_versions(song.id) == []
+        storage.touch_version(song.id, 2.0, 1.5)
         versions = storage.list_versions(song.id)
         assert versions == [(2.0, 1.5)]
 
@@ -195,6 +207,7 @@ class TestVersionStorage:
         for stem in StemName:
             path = storage.processed_path(song.id, stem, -3.0, 0.75)
             path.write_bytes(b"\x00" * 10)
+        storage.touch_version(song.id, -3.0, 0.75)
         versions = storage.list_versions(song.id)
         assert versions == [(-3.0, 0.75)]
 
@@ -204,6 +217,9 @@ class TestVersionStorage:
         storage.processed_path(song.id, StemName.BASS, 0.0, 0.5).write_bytes(b"\x00")
         storage.processed_path(song.id, StemName.BASS, 2.0, 1.0).write_bytes(b"\x00")
         storage.processed_path(song.id, StemName.BASS, -1.0, 1.25).write_bytes(b"\x00")
+        storage.touch_version(song.id, 0.0, 0.5)
+        storage.touch_version(song.id, 2.0, 1.0)
+        storage.touch_version(song.id, -1.0, 1.25)
         versions = storage.list_versions(song.id)
         assert len(versions) == 3
         assert (-1.0, 1.25) in versions
@@ -211,7 +227,12 @@ class TestVersionStorage:
         assert (2.0, 1.0) in versions
 
     def test_list_versions_ignores_unknown_files(self, storage: SongStorage) -> None:
-        """Files with unexpected names are silently ignored."""
+        """Unregistered files on disk (no versions.json entry) are not listed.
+
+        Under the new design, list_versions reads from versions.json.  Stray
+        files that were never committed via touch_version (e.g. left by a
+        crashed process) are silently ignored.
+        """
         song = storage.create_song("song.mp3")
         proc_dir = storage.processed_output_dir(song.id)
         proc_dir.mkdir(parents=True, exist_ok=True)
@@ -220,12 +241,16 @@ class TestVersionStorage:
         assert storage.list_versions(song.id) == []
 
     def test_delete_version_removes_files(self, storage: SongStorage) -> None:
-        """delete_version removes all stem files for the given pair."""
+        """delete_version removes all stem files and the versions.json entry."""
         song = storage.create_song("song.mp3")
         for stem in StemName:
             storage.processed_path(song.id, stem, 1.0, 1.2).write_bytes(b"\x00")
+        storage.touch_version(song.id, 1.0, 1.2)
+        # Version is visible before deletion.
+        assert storage.list_versions(song.id) == [(1.0, 1.2)]
         count = storage.delete_version(song.id, 1.0, 1.2)
         assert count == len(list(StemName))
+        # Version disappears from the registry after deletion.
         assert storage.list_versions(song.id) == []
 
     def test_delete_version_returns_zero_when_not_found(

--- a/frontend/legacy/app.js
+++ b/frontend/legacy/app.js
@@ -203,7 +203,8 @@ function renderVersions() {
     const li = document.createElement("li");
     li.className = "version-item" +
       (ver.is_default ? " default-version" : "") +
-      (isActive ? " active" : "");
+      (isActive ? " active" : "") +
+      (ver.status === "processing" ? " status-processing" : "");
     li.title = `Pitch: ${pitchStr} semitones, Tempo: ${tempoStr}`;
 
     const labelSpan = document.createElement("span");
@@ -212,11 +213,10 @@ function renderVersions() {
 
     // Status badge for non-default versions
     if (!ver.is_default) {
-      const badge = document.createElement("span");
-      const statusText = ver.status === "processing" ? "⏳" : ver.status === "partial" ? "partial" : "";
-      if (statusText) {
-        badge.className = `version-status-badge status-${ver.status}`;
-        badge.textContent = statusText;
+      if (ver.status === "partial") {
+        const badge = document.createElement("span");
+        badge.className = "version-status-badge status-partial";
+        badge.textContent = "partial";
         li.appendChild(badge);
       }
       if (ver.accessed_at) {

--- a/frontend/legacy/style.css
+++ b/frontend/legacy/style.css
@@ -401,9 +401,7 @@ footer {
   flex-shrink: 0;
 }
 
-.version-status-badge.status-processing {
-  background: #854d0e;
-  color: #fef9c3;
+.version-item.status-processing {
   animation: stem-pulse 1.2s ease-in-out infinite;
 }
 

--- a/frontend/src/components/VersionsPicker.tsx
+++ b/frontend/src/components/VersionsPicker.tsx
@@ -101,6 +101,7 @@ export function VersionsPicker({ onSelectVersion }: Props) {
                 ver.is_default ? "default-version" : "",
                 isActive ? "active" : "",
                 isClientCached ? "version-cached" : "",
+                ver.status === "processing" ? "status-processing" : "",
               ]
                 .filter(Boolean)
                 .join(" ")}
@@ -112,9 +113,9 @@ export function VersionsPicker({ onSelectVersion }: Props) {
 
               {!ver.is_default && (
                 <>
-                  {(ver.status === "processing" || ver.status === "partial") && (
-                    <span className={`version-status-badge status-${ver.status}`}>
-                      {ver.status === "processing" ? "⏳" : "partial"}
+                  {ver.status === "partial" && (
+                    <span className="version-status-badge status-partial">
+                      partial
                     </span>
                   )}
                   {ver.status !== "processing" && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -401,7 +401,7 @@ a:hover { text-decoration: underline; }
   border-radius: 10px;
   font-weight: 600;
 }
-.version-status-badge.status-processing { background: #555; color: #ddd; animation: pulse 1.2s ease-in-out infinite; }
+.version-item.status-processing { animation: pulse 1.2s ease-in-out infinite; }
 .version-status-badge.status-partial { background: #4a4a4a; color: #ccc; }
 .version-item.version-cached { border-left: 3px solid var(--color-accent); padding-left: calc(0.65rem - 3px); }
 

--- a/frontend/src/test/components/VersionsPicker.test.tsx
+++ b/frontend/src/test/components/VersionsPicker.test.tsx
@@ -95,10 +95,10 @@ describe("VersionsPicker", () => {
     expect(onSelectVersion).toHaveBeenCalledWith(3, 0.9);
   });
 
-  it("shows processing badge for a version in processing state", () => {
+  it("pulses the version bubble for a version in processing state", () => {
     resetStore([processingVersion]);
     render(<VersionsPicker onSelectVersion={vi.fn()} />);
-    expect(document.querySelector(".status-processing")).toBeInTheDocument();
+    expect(document.querySelector(".version-item.status-processing")).toBeInTheDocument();
   });
 
   it("processing version is not clickable (no cursor:pointer)", () => {


### PR DESCRIPTION
This pull request refactors how processed audio versions are tracked and displayed, ensuring that only fully processed and registered versions are shown as "ready" in the UI. The backend now uses a `versions.json` registry as the single source of truth for available versions, and the frontend updates its logic and styling to accurately reflect processing states. These changes prevent the UI from prematurely indicating that a version is ready before processing is complete, improving reliability and user experience.

**Backend: Version registration and listing improvements**
* `SongStorage.list_versions` now reads exclusively from `versions.json`, only listing versions that have been explicitly registered via `touch_version`. This prevents in-progress or orphaned files from appearing as ready, and ensures the UI only shows truly available versions.
* The processing pipeline writes output files to a temporary location and atomically renames them upon completion, ensuring that incomplete files are never visible to version listing or status checks.
* Extensive test updates clarify and verify the new behavior: versions are only listed after registration, default versions are handled correctly, and stray or partially processed files are ignored. [[1]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L1105-R1116) [[2]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L1129-R1137) [[3]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550R1146-R1147) [[4]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550R1432-R1443) [[5]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dL177-R198) [[6]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR210) [[7]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR220-R235) [[8]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dL223-R253)

**Frontend: UI feedback and styling updates**
* The "processing" status is now indicated by a pulsing animation on the version bubble itself, rather than a badge, for both legacy and modern frontends. [[1]](diffhunk://#diff-d57a5b258c2aabd5fc92bcfbf6034e383616a96d7384210cea17ab9f369a060fL206-R207) [[2]](diffhunk://#diff-992f1fed3778de61ece1994ce66ad911b628c7dd9a8f724127bb80767607b21cR104) [[3]](diffhunk://#diff-551983017b0533b7cad258acd27d44843199716f1ba8b59d4183325d9f1222b9L404-R404) [[4]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L404-R404)
* The "partial" status continues to show a badge, while processing status no longer displays a badge but uses the new animation. [[1]](diffhunk://#diff-d57a5b258c2aabd5fc92bcfbf6034e383616a96d7384210cea17ab9f369a060fR216-R219) [[2]](diffhunk://#diff-992f1fed3778de61ece1994ce66ad911b628c7dd9a8f724127bb80767607b21cL115-R118)
* Tests for the version picker component are updated to expect the new animation-based indicator for processing versions.

**Documentation and code comments**
* Docstrings and comments are revised throughout the backend and tests to clarify the new source of truth (`versions.json`) and the rationale behind atomic file operations and version registration. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R620-R626) [[2]](diffhunk://#diff-bd48d0ec4240895029aa63f46e8f5d8ccbb1c31b1f1dbeb87130127e71570550L1105-R1116) [[3]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dL177-R198) [[4]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR220-R235)

These changes together make the version status reporting more robust and prevent UI inconsistencies caused by partially written files or unregistered versions.## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
