### PR TITLE
feat: unify pending and cached display

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN npm run build
 FROM python:3.14-slim AS builder
 
 # Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.3@sha256:90bbb3c16635e9627f49eec6539f956d70746c409209041800a0280b93152823 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.8@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/e2e/test_ui.py
+++ b/e2e/test_ui.py
@@ -60,13 +60,19 @@ class TestSongList:
         # Use .first because the session may have multiple songs.
         expect(page.locator(".song-item").first).to_be_visible()
 
-    def test_ready_song_shows_ready_badge(self, page: Page, ready_song_id: str) -> None:
+    def test_ready_song_shows_enabled_load_button(
+        self, page: Page, ready_song_id: str
+    ) -> None:
+        """A ready song exposes its status via an enabled load button (no separate badge)."""
         page.goto("/")
-        expect(page.locator(".status-ready").first).to_be_visible()
+        song_item = page.locator(f'.song-item[data-id="{ready_song_id}"]')
+        load_btn = song_item.locator(".song-load-btn")
+        expect(load_btn).to_be_visible()
+        expect(load_btn).not_to_be_disabled()
 
     def test_ready_song_has_load_button(self, page: Page, ready_song_id: str) -> None:
         page.goto("/")
-        expect(page.locator(".song-item .btn-primary").first).to_be_visible()
+        expect(page.locator(".song-item .song-load-btn").first).to_be_visible()
 
     def test_refresh_button_present(self, page: Page) -> None:
         page.goto("/")
@@ -104,7 +110,7 @@ class TestPlayerSection:
         # Target the specific song row by data-id to be robust when
         # multiple songs are present in the test session data directory.
         song_item = page.locator(f'.song-item[data-id="{ready_song_id}"]')
-        load_btn = song_item.locator(".btn-primary")
+        load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
         return page
@@ -130,7 +136,7 @@ class TestPlayerSection:
         )
 
         song_item = page.locator(f'.song-item[data-id="{ready_song_id}"]')
-        load_btn = song_item.locator(".btn-primary")
+        load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
         return page
@@ -155,7 +161,7 @@ class TestPlayerSection:
         """When a song has embedded tags the player title shows artist and title."""
         page.goto("/")
         song_item = page.locator(f'.song-item[data-id="{ready_song_with_metadata_id}"]')
-        load_btn = song_item.locator(".btn-primary")
+        load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
         title = page.locator("#player-title")
@@ -200,7 +206,7 @@ class TestEqualizer:
         """Navigate to the app, load the ready song, then open the EQ tab."""
         page.goto("/")
         song_item = page.locator(f'.song-item[data-id="{ready_song_id}"]')
-        load_btn = song_item.locator(".btn-primary")
+        load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
         # Navigate to the EQ tab via BottomNav

--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -1,21 +1,14 @@
-import { useMemo } from "react";
+import { useMemo, useEffect, useState } from "react";
 import { usePlayerStore } from "../store/playerStore";
 import type { SongSortOrder } from "../store/playerStore";
 import { api } from "../api/client";
 import type { Song } from "../types";
 import { getSongArtist, getSongLabel, getSongTitle } from "../utils/songDisplay";
 import { sortSongs } from "../utils/songSort";
+import { hasCached } from "../audio/audioCache";
 
 interface Props {
   onLoadSong: (song: Song) => void;
-}
-
-function statusLabel(status: string): string {
-  return (
-    { uploaded: "Uploaded", splitting: "Splitting…", ready: "Ready", error: "Error" }[
-      status
-    ] ?? status
-  );
 }
 
 export function SongList({ onLoadSong }: Props) {
@@ -24,6 +17,26 @@ export function SongList({ onLoadSong }: Props) {
   const setSongs = usePlayerStore((s) => s.setSongs);
   const songSortOrder = usePlayerStore((s) => s.songSortOrder);
   const setSongSortOrder = usePlayerStore((s) => s.setSongSortOrder);
+
+  const [cachedSongIds, setCachedSongIds] = useState<Set<string>>(new Set());
+
+  // Check which songs have their main stems fully cached in the SW stem cache.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const nextCached = new Set<string>();
+      for (const song of songs) {
+        if (song.stems.length === 0) continue;
+        const urls = song.stems.map((stem) => api.stemUrl(song.id, stem));
+        const cached = await hasCached(urls);
+        if (cached) nextCached.add(song.id);
+      }
+      if (!cancelled) setCachedSongIds(nextCached);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [songs]);
 
   const handleDelete = async (id: string) => {
     if (!confirm("Delete this song and all its stems?")) return;
@@ -82,17 +95,24 @@ export function SongList({ onLoadSong }: Props) {
                 <span className="song-title">{getSongTitle(song)}</span>
               </span>
 
-              <span className={`song-status-badge status-${song.status}`}>
-                {statusLabel(song.status)}
-              </span>
-
               <div className="song-actions">
-                {song.status === "ready" && (
+                {(song.status === "ready" || song.status === "splitting") && (
                   <button
-                    className="btn btn-sm btn-primary"
-                    onClick={() => onLoadSong(song)}
+                    className={[
+                      "btn btn-sm btn-primary song-load-btn",
+                      song.status === "splitting" ? "status-splitting" : "",
+                      cachedSongIds.has(song.id) ? "song-cached" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    onClick={song.status === "ready" ? () => onLoadSong(song) : undefined}
+                    disabled={song.status === "splitting"}
                   >
-                    {activeSong?.id === song.id ? "Active" : "Load"}
+                    {song.status === "splitting"
+                      ? "Splitting…"
+                      : activeSong?.id === song.id
+                        ? "Active"
+                        : "Load"}
                   </button>
                 )}
                 <button

--- a/frontend/src/components/VersionsPicker.tsx
+++ b/frontend/src/components/VersionsPicker.tsx
@@ -98,7 +98,6 @@ export function VersionsPicker({ onSelectVersion }: Props) {
               key={`${ver.pitch_semitones}-${ver.tempo_ratio}`}
               className={[
                 "version-item",
-                ver.is_default ? "default-version" : "",
                 isActive ? "active" : "",
                 isClientCached ? "version-cached" : "",
                 ver.status === "processing" ? "status-processing" : "",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -382,7 +382,6 @@ a:hover { text-decoration: underline; }
 }
 .version-item:hover { border-color: var(--color-accent); }
 .version-item.active { border-color: var(--color-accent); background: rgba(255,255,255,0.06); font-weight: 600; }
-.version-item.default-version { border-style: dashed; }
 .version-delete-btn {
   background: none;
   border: none;
@@ -404,6 +403,10 @@ a:hover { text-decoration: underline; }
 .version-item.status-processing { animation: pulse 1.2s ease-in-out infinite; }
 .version-status-badge.status-partial { background: #4a4a4a; color: #ccc; }
 .version-item.version-cached { border-left: 3px solid var(--color-accent); padding-left: calc(0.65rem - 3px); }
+
+/* ---------- Song list load-button states ---------- */
+.song-load-btn.status-splitting { animation: pulse 1.2s ease-in-out infinite; }
+.song-load-btn.song-cached { border-left: 3px solid var(--color-accent); padding-left: calc(0.65rem - 3px); }
 
 /* ---------- Stems stack (vertical) ---------- */
 .stems-stack {

--- a/frontend/src/test/components/SongList.test.tsx
+++ b/frontend/src/test/components/SongList.test.tsx
@@ -1,14 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { SongList } from "../../components/SongList";
 import { usePlayerStore } from "../../store/playerStore";
 import type { Song } from "../../types";
+
+vi.mock("../../audio/audioCache", () => ({
+  hasCached: vi.fn().mockResolvedValue(false),
+}));
 
 // Mock the api module
 vi.mock("../../api/client", () => ({
   api: {
     deleteSong: vi.fn().mockResolvedValue(undefined),
     getSongs: vi.fn().mockResolvedValue({ songs: [] }),
+    stemUrl: vi.fn().mockImplementation((id: string, stem: string) => `/api/songs/${id}/stems/${stem}`),
   },
 }));
 
@@ -61,22 +66,30 @@ describe("SongList", () => {
     expect(document.querySelectorAll(".song-item")).toHaveLength(2);
   });
 
-  it("shows 'Ready' badge for ready song", () => {
-    resetStore([readySong]);
+  it("does not render a status badge for any song", () => {
+    resetStore([readySong, splittingSong, errorSong]);
     render(<SongList onLoadSong={vi.fn()} />);
-    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(document.querySelector(".song-status-badge")).not.toBeInTheDocument();
   });
 
-  it("shows 'Splitting…' badge for splitting song", () => {
+  it("shows disabled 'Splitting…' button for splitting song", () => {
     resetStore([splittingSong]);
     render(<SongList onLoadSong={vi.fn()} />);
-    expect(screen.getByText("Splitting…")).toBeInTheDocument();
+    const btn = screen.getByText("Splitting…");
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeDisabled();
   });
 
-  it("shows 'Error' badge for error song", () => {
+  it("splitting button has status-splitting class (pulsates)", () => {
+    resetStore([splittingSong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    expect(document.querySelector(".song-load-btn.status-splitting")).toBeInTheDocument();
+  });
+
+  it("does not show a load button for error songs", () => {
     resetStore([errorSong]);
     render(<SongList onLoadSong={vi.fn()} />);
-    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(document.querySelector(".song-load-btn")).not.toBeInTheDocument();
   });
 
   it("shows Load button only for ready songs", () => {
@@ -135,5 +148,39 @@ describe("SongList", () => {
     const select = screen.getByRole("combobox", { name: "Sort order" });
     fireEvent.change(select, { target: { value: "alphabetical" } });
     expect(usePlayerStore.getState().songSortOrder).toBe("alphabetical");
+  });
+
+  it("load button has song-cached class when all stems are in SW cache", async () => {
+    const audioCache = await import("../../audio/audioCache");
+    vi.mocked(audioCache.hasCached).mockResolvedValue(true);
+    resetStore([readySong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    await waitFor(() => {
+      expect(document.querySelector(".song-load-btn.song-cached")).toBeInTheDocument();
+    });
+  });
+
+  it("does not add song-cached class when stems are not in SW cache", async () => {
+    const audioCache = await import("../../audio/audioCache");
+    vi.mocked(audioCache.hasCached).mockResolvedValue(false);
+    resetStore([readySong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(document.querySelector(".song-load-btn.song-cached")).not.toBeInTheDocument();
+  });
+
+  it("uses stemUrl to check cache for each stem", async () => {
+    const audioCache = await import("../../audio/audioCache");
+    const { api } = await import("../../api/client");
+    vi.mocked(audioCache.hasCached).mockResolvedValue(true);
+    resetStore([readySong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    await waitFor(() => {
+      expect(document.querySelector(".song-load-btn.song-cached")).toBeInTheDocument();
+    });
+    expect(vi.mocked(api.stemUrl)).toHaveBeenCalledWith("s1", "vocals");
+    expect(vi.mocked(api.stemUrl)).toHaveBeenCalledWith("s1", "bass");
   });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 
 [tool.uv]
 # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-required-version = "0.11.3"
+required-version = "0.11.8"
 package = false
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This pull request updates the `SongList` component to improve how song loading and caching states are displayed and handled. It removes the old status badge in favor of a more interactive load button that reflects the song's status and cache state, and it adds logic to visually indicate when a song's stems are fully cached. Tests are updated and expanded to cover these new behaviors. Additionally, some unused styles related to version items are cleaned up.

**Song loading and caching UX improvements:**

* The `SongList` component now checks if all stems for each song are cached and visually marks the load button with a `song-cached` class when they are, using the new `hasCached` logic and a `cachedSongIds` state.
* The status badge for songs has been removed; instead, the load button now displays the song's status ("Splitting…", "Active", or "Load") and is disabled when splitting. The button also shows a pulsating animation when splitting and a visual indicator if cached. [[1]](diffhunk://#diff-b0cc214f3fd6c8cfddb220c8e78f583f4b7f003cc8c453fe097b7c9a93f3f8dfL85-R115) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R407-R410)

**Testing updates:**

* Tests for `SongList` are updated to check that the status badge is no longer rendered, the load button reflects the correct state and classes, and that caching logic is properly invoked and reflected in the UI. [[1]](diffhunk://#diff-bd3ffc6cc2b3e4defdc809f8f4a081f2649ad47d29aeae55fc48adacf4d9cb7cL2-R16) [[2]](diffhunk://#diff-bd3ffc6cc2b3e4defdc809f8f4a081f2649ad47d29aeae55fc48adacf4d9cb7cL64-R92) [[3]](diffhunk://#diff-bd3ffc6cc2b3e4defdc809f8f4a081f2649ad47d29aeae55fc48adacf4d9cb7cR152-R185)

**Code and style cleanup:**

* Unused code and styles related to version item default highlighting are removed from both the component and CSS. [[1]](diffhunk://#diff-992f1fed3778de61ece1994ce66ad911b628c7dd9a8f724127bb80767607b21cL101) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L385)## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
