### PR TITLE
feat: new shift left function for ab looping

### DIFF
--- a/frontend/src/components/PlaybackBar.tsx
+++ b/frontend/src/components/PlaybackBar.tsx
@@ -17,6 +17,7 @@ interface Props {
   onLoopSetBValue: (val: number) => void;
   onLoopAdjustA: (delta: number) => void;
   onLoopAdjustB: (delta: number) => void;
+  onLoopShift: () => void;
 }
 
 function SkipBackIcon({ seconds }: { seconds: number }) {
@@ -108,6 +109,7 @@ export function PlaybackBar({
   onLoopSetBValue,
   onLoopAdjustA,
   onLoopAdjustB,
+  onLoopShift,
 }: Props) {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const isLoading = usePlayerStore((s) => s.isLoading);
@@ -279,6 +281,16 @@ export function PlaybackBar({
           onClick={onLoopClear}
         >
           Clear
+        </button>
+        <button
+          id="loop-shift-btn"
+          className="btn btn-sm btn-secondary"
+          title="Shift loop: A←B, B←song end"
+          aria-label="Shift loop: A to old B, B to song end"
+          disabled={!loopEnabled}
+          onClick={onLoopShift}
+        >
+          A&lt;B&lt;Ω
         </button>
 
       </div>

--- a/frontend/src/components/PlayerSection.tsx
+++ b/frontend/src/components/PlayerSection.tsx
@@ -429,6 +429,21 @@ export function PlayerSection() {
     }
   };
 
+  const handleLoopShift = () => {
+    // Shift loop window forward: new A = old B, new B = song end.
+    // This starts a new loop section that begins where the old one ended.
+    const s = usePlayerStore.getState();
+    const newA = s.loopEnd ?? s.duration;
+    const newB = s.duration;
+    setLoopStart(newA);
+    setLoopEnd(newB);
+    if (isPlaying) {
+      eng.stopSources();
+      eng.stopSeekTimer();
+      playAll(newA);
+    }
+  };
+
   const handleLoopSetAValue = (val: number) => {
     const s = usePlayerStore.getState();
     const newStart = Math.max(0, Math.min(val, s.loopEnd ?? s.duration));
@@ -719,6 +734,7 @@ export function PlayerSection() {
         onLoopSetBValue={handleLoopSetBValue}
         onLoopAdjustA={handleLoopAdjustA}
         onLoopAdjustB={handleLoopAdjustB}
+        onLoopShift={handleLoopShift}
       />
     </section>
   );

--- a/frontend/src/test/components/PlaybackBar.test.tsx
+++ b/frontend/src/test/components/PlaybackBar.test.tsx
@@ -36,6 +36,7 @@ const defaultProps = {
   onLoopSetBValue: vi.fn(),
   onLoopAdjustA: vi.fn(),
   onLoopAdjustB: vi.fn(),
+  onLoopShift: vi.fn(),
 };
 
 describe("PlaybackBar", () => {
@@ -200,5 +201,24 @@ describe("PlaybackBar", () => {
     render(<PlaybackBar {...defaultProps} onLoopAdjustB={onLoopAdjustB} />);
     fireEvent.click(screen.getByRole("button", { name: "Move B point +5 seconds" }));
     expect(onLoopAdjustB).toHaveBeenCalledWith(5);
+  });
+
+  it("A<B<Ω button is disabled when loop is not enabled", () => {
+    render(<PlaybackBar {...defaultProps} />);
+    expect(document.querySelector("#loop-shift-btn")).toBeDisabled();
+  });
+
+  it("A<B<Ω button is enabled when loop is enabled", () => {
+    usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 40 });
+    render(<PlaybackBar {...defaultProps} />);
+    expect(document.querySelector("#loop-shift-btn")).not.toBeDisabled();
+  });
+
+  it("calls onLoopShift when A<B<Ω button is clicked (loop enabled)", () => {
+    usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 40 });
+    const onLoopShift = vi.fn();
+    render(<PlaybackBar {...defaultProps} onLoopShift={onLoopShift} />);
+    fireEvent.click(document.querySelector("#loop-shift-btn")!);
+    expect(onLoopShift).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/test/components/PlayerSection.test.tsx
+++ b/frontend/src/test/components/PlayerSection.test.tsx
@@ -566,6 +566,39 @@ describe("PlayerSection", () => {
     expect(eng.stopSources).toHaveBeenCalled();
   });
 
+  it("loop Shift sets A to old B and B to song end", async () => {
+    usePlayerStore.setState({ activeSong: readySong });
+    await act(async () => {
+      render(<PlayerSection />);
+    });
+    // duration is set to getDuration() mock = 100 after load
+    await act(async () => {
+      usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 40 });
+    });
+    await act(async () => {
+      fireEvent.click(document.querySelector("#loop-shift-btn")!);
+    });
+    expect(usePlayerStore.getState().loopStart).toBe(40);
+    expect(usePlayerStore.getState().loopEnd).toBe(100); // duration from mock
+    expect(usePlayerStore.getState().duration).toBe(100); // duration unchanged
+  });
+
+  it("loop Shift when isPlaying=true stops and restarts at new A", async () => {
+    usePlayerStore.setState({ activeSong: readySong });
+    await act(async () => {
+      render(<PlayerSection />);
+    });
+    await act(async () => {
+      usePlayerStore.setState({ isPlaying: true, loopEnabled: true, loopStart: 10, loopEnd: 40 });
+    });
+    const eng = await import("../../audio/engine");
+    await act(async () => {
+      fireEvent.click(document.querySelector("#loop-shift-btn")!);
+    });
+    expect(eng.stopSources).toHaveBeenCalled();
+    expect(eng.playAll).toHaveBeenCalled();
+  });
+
   it("Precalculate button calls createVersion and refreshes versions list on success", async () => {
     vi.mocked(api.createVersion).mockResolvedValue(undefined as never);
     vi.mocked(api.getVersions)


### PR DESCRIPTION
This pull request adds a new "Shift Loop" feature to the playback controls, allowing users to quickly shift the loop region forward so that the new loop starts at the old loop end and extends to the end of the song. The feature is fully integrated into the UI, state management, and tested for both enabled/disabled states and playback behavior.

**Playback Bar and Loop Controls:**

* Added a new `onLoopShift` prop to the `PlaybackBar` component and a corresponding "A<B<Ω" button in the UI, which is enabled only when looping is active. Clicking this button triggers the loop shift action. [[1]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR20) [[2]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR112) [[3]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR285-R294)

**Player Section Logic:**

* Implemented the `handleLoopShift` handler in `PlayerSection`, which updates the loop start to the old loop end and the loop end to the song duration. If playback is active, it stops and restarts playback at the new loop start.

**Wiring and Integration:**

* Passed the new `onLoopShift` handler from `PlayerSection` to `PlaybackBar`, ensuring the button is functional in the main UI.

**Testing:**

* Updated and added tests in `PlaybackBar.test.tsx` to verify the button is enabled/disabled appropriately and calls the handler when clicked. [[1]](diffhunk://#diff-a6a61130f76dd5c726bdf94254f063c17a1d2964b77b8b2f91a48a2ac7f601a8R39) [[2]](diffhunk://#diff-a6a61130f76dd5c726bdf94254f063c17a1d2964b77b8b2f91a48a2ac7f601a8R205-R223)
* Added tests in `PlayerSection.test.tsx` to ensure the loop shift updates loop points correctly and restarts playback when necessary.## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
