### PR TITLE
feat: persistent ab loop list per song

### DIFF
--- a/frontend/src/components/PlaybackBar.tsx
+++ b/frontend/src/components/PlaybackBar.tsx
@@ -18,6 +18,11 @@ interface Props {
   onLoopAdjustA: (delta: number) => void;
   onLoopAdjustB: (delta: number) => void;
   onLoopShift: () => void;
+  onAddCurrentToHistory: () => void;
+  onRemoveCurrentInterval: () => void;
+  onRestoreHistoryItem: (index: number) => void;
+  onRemoveHistoryItem: (index: number) => void;
+  onClearLoopHistory: () => void;
 }
 
 function SkipBackIcon({ seconds }: { seconds: number }) {
@@ -110,6 +115,11 @@ export function PlaybackBar({
   onLoopAdjustA,
   onLoopAdjustB,
   onLoopShift,
+  onAddCurrentToHistory,
+  onRemoveCurrentInterval,
+  onRestoreHistoryItem,
+  onRemoveHistoryItem,
+  onClearLoopHistory,
 }: Props) {
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const isLoading = usePlayerStore((s) => s.isLoading);
@@ -118,6 +128,7 @@ export function PlaybackBar({
   const loopEnabled = usePlayerStore((s) => s.loopEnabled);
   const loopStart = usePlayerStore((s) => s.loopStart);
   const loopEnd = usePlayerStore((s) => s.loopEnd);
+  const loopHistory = usePlayerStore((s) => s.loopHistory);
 
   const pos = Math.min(startOffset, duration || startOffset);
 
@@ -383,6 +394,84 @@ export function PlaybackBar({
             </button>
           ))}
         </div>
+      </div>
+
+      {/* Loop interval history */}
+      <div className="loop-history" id="loop-history">
+        <div className="loop-history-header">
+          <span className="loop-history-title">Intervals</span>
+          <div className="loop-history-header-actions">
+            <button
+              className="btn btn-xs btn-secondary"
+              id="loop-history-add-btn"
+              title="Add current interval to history"
+              onClick={onAddCurrentToHistory}
+            >
+              Add
+            </button>
+            <button
+              className="btn btn-xs btn-secondary"
+              id="loop-history-clear-btn"
+              title="Clear all saved intervals"
+              disabled={loopHistory.length === 0}
+              onClick={onClearLoopHistory}
+            >
+              Clear all
+            </button>
+          </div>
+        </div>
+
+        {/* Current interval */}
+        <div className="loop-history-item current" id="loop-history-current">
+          <span className="loop-history-label">Now</span>
+          <span className="loop-history-range">
+            {loopStart !== null ? fmtTime(loopStart) : "—"}
+            {" \u2013 "}
+            {loopEnd !== null ? fmtTime(loopEnd) : "—"}
+          </span>
+          <button
+            className="loop-history-remove"
+            aria-label="Remove current interval"
+            title="Remove current interval"
+            onClick={onRemoveCurrentInterval}
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Archived intervals */}
+        {loopHistory.map((item, i) => (
+          <div
+            key={i}
+            className="loop-history-item"
+            id={`loop-history-item-${i}`}
+            onClick={() => onRestoreHistoryItem(i)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onRestoreHistoryItem(i); }}
+            aria-label={`Restore interval ${i + 1}`}
+          >
+            <span className="loop-history-label">#{i + 1}</span>
+            <button
+              className="loop-history-restore"
+              aria-hidden="true"
+              tabIndex={-1}
+              onClick={(e) => { e.stopPropagation(); onRestoreHistoryItem(i); }}
+            >
+              {item.a !== null ? fmtTime(item.a) : "—"}
+              {" \u2013 "}
+              {item.b !== null ? fmtTime(item.b) : "—"}
+            </button>
+            <button
+              className="loop-history-remove"
+              aria-label={`Remove interval ${i + 1}`}
+              title={`Remove interval ${i + 1}`}
+              onClick={(e) => { e.stopPropagation(); onRemoveHistoryItem(i); }}
+            >
+              &times;
+            </button>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/components/PlayerSection.tsx
+++ b/frontend/src/components/PlayerSection.tsx
@@ -13,9 +13,11 @@ import { getSongArtist, getSongTitle } from "../utils/songDisplay";
 
 const POLL_MS = 2000;
 const LAST_SELECTED_VERSIONS_KEY = "bass-karaoke-player:last-selected-versions";
+const LOOP_HISTORY_KEY_PREFIX = "bass-karaoke-player:loop-history";
 
 type LastSelectedVersion = { pitch: number; tempo: number };
 type LastSelectedVersionsBySong = Record<string, LastSelectedVersion>;
+type LoopHistoryItem = { a: number | null; b: number | null };
 
 const readLastSelectedVersions = (): LastSelectedVersionsBySong => {
   try {
@@ -36,6 +38,35 @@ const readLastSelectedVersions = (): LastSelectedVersionsBySong => {
     return result;
   } catch {
     return {};
+  }
+};
+
+const readLoopHistory = (songId: string): LoopHistoryItem[] => {
+  try {
+    const raw = window.localStorage.getItem(`${LOOP_HISTORY_KEY_PREFIX}:${songId}`);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item): item is LoopHistoryItem =>
+        item !== null &&
+        typeof item === "object" &&
+        (item.a === null || typeof item.a === "number") &&
+        (item.b === null || typeof item.b === "number"),
+    );
+  } catch {
+    return [];
+  }
+};
+
+const persistLoopHistory = (songId: string, items: LoopHistoryItem[]): void => {
+  try {
+    window.localStorage.setItem(
+      `${LOOP_HISTORY_KEY_PREFIX}:${songId}`,
+      JSON.stringify(items),
+    );
+  } catch {
+    // ignore
   }
 };
 
@@ -65,6 +96,10 @@ export function PlayerSection() {
   const setLoopEnabled = usePlayerStore((s) => s.setLoopEnabled);
   const setLoopStart = usePlayerStore((s) => s.setLoopStart);
   const setLoopEnd = usePlayerStore((s) => s.setLoopEnd);
+  const pushLoopHistoryItem = usePlayerStore((s) => s.pushLoopHistoryItem);
+  const removeLoopHistoryItem = usePlayerStore((s) => s.removeLoopHistoryItem);
+  const clearLoopHistory = usePlayerStore((s) => s.clearLoopHistory);
+  const setLoopHistory = usePlayerStore((s) => s.setLoopHistory);
   const activeVersion = usePlayerStore((s) => s.activeVersion);
   const [stemsCollapsed, setStemsCollapsed] = useState(false);
   const [isPrecalculating, setIsPrecalculating] = useState(false);
@@ -479,6 +514,52 @@ export function PlayerSection() {
     handleLoopSetBValue(current + delta);
   };
 
+  const handleAddCurrentToHistory = () => {
+    const s = usePlayerStore.getState();
+    if (s.loopStart === null && s.loopEnd === null) return;
+    pushLoopHistoryItem({ a: s.loopStart, b: s.loopEnd });
+    if (activeSong) persistLoopHistory(activeSong.id, usePlayerStore.getState().loopHistory);
+  };
+
+  const handleRemoveCurrentInterval = () => {
+    setLoopStart(null);
+    setLoopEnd(null);
+    setLoopEnabled(false);
+    if (isPlaying) {
+      const offset = getCurrentPos();
+      eng.stopSources();
+      eng.stopSeekTimer();
+      playAll(offset);
+    }
+  };
+
+  const handleRestoreHistoryItem = (index: number) => {
+    const s = usePlayerStore.getState();
+    const item = s.loopHistory[index];
+    if (!item) return;
+    setLoopStart(item.a);
+    setLoopEnd(item.b);
+    if (item.a !== null && item.b !== null) {
+      setLoopEnabled(true);
+    }
+    if (isPlaying) {
+      const newStart = item.a ?? 0;
+      eng.stopSources();
+      eng.stopSeekTimer();
+      playAll(newStart);
+    }
+  };
+
+  const handleRemoveHistoryItem = (index: number) => {
+    removeLoopHistoryItem(index);
+    if (activeSong) persistLoopHistory(activeSong.id, usePlayerStore.getState().loopHistory);
+  };
+
+  const handleClearLoopHistory = () => {
+    clearLoopHistory();
+    if (activeSong) persistLoopHistory(activeSong.id, []);
+  };
+
   // -----------------------------------------------------------------------
   // Global controls (pitch/tempo)
   // -----------------------------------------------------------------------
@@ -616,6 +697,7 @@ export function PlayerSection() {
     setLoopEnabled(false);
     setLoopStart(null);
     setLoopEnd(null);
+    setLoopHistory(readLoopHistory(activeSong.id));
     initStemControls(activeSong.stems);
     setVersions([]);
 
@@ -735,6 +817,11 @@ export function PlayerSection() {
         onLoopAdjustA={handleLoopAdjustA}
         onLoopAdjustB={handleLoopAdjustB}
         onLoopShift={handleLoopShift}
+        onAddCurrentToHistory={handleAddCurrentToHistory}
+        onRemoveCurrentInterval={handleRemoveCurrentInterval}
+        onRestoreHistoryItem={handleRestoreHistoryItem}
+        onRemoveHistoryItem={handleRemoveHistoryItem}
+        onClearLoopHistory={handleClearLoopHistory}
       />
     </section>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -574,6 +574,96 @@ a:hover { text-decoration: underline; }
   .playback-buttons .btn { flex: 0 0 auto; }
 }
 
+/* ---------- Loop interval history ---------- */
+.loop-history {
+  margin-top: 0.75rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.loop-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+}
+.loop-history-header-actions {
+  display: flex;
+  gap: 0.3rem;
+}
+.loop-history-title {
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.loop-history-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.82rem;
+  border: 1px solid rgba(160, 160, 160, 0.22);
+  background: rgba(160, 160, 160, 0.06);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.loop-history-item:hover {
+  background: rgba(160, 160, 160, 0.14);
+  border-color: rgba(160, 160, 160, 0.4);
+}
+.loop-history-item.current {
+  background: rgba(99, 179, 237, 0.1);
+  border: 1px solid rgba(99, 179, 237, 0.25);
+  cursor: default;
+}
+.loop-history-item.current:hover {
+  background: rgba(99, 179, 237, 0.1);
+  border-color: rgba(99, 179, 237, 0.25);
+}
+.loop-history-label {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  min-width: 2.5rem;
+}
+.loop-history-range {
+  flex: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+.loop-history-restore {
+  flex: 1;
+  font-variant-numeric: tabular-nums;
+  background: none;
+  border: none;
+  color: var(--color-text);
+  text-align: left;
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+}
+.loop-history-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-muted);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 0.2rem;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+}
+.loop-history-remove:hover {
+  color: var(--color-text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
 /* ---------- Equalizer ---------- */
 #eq-section .card {
   padding: 1rem;

--- a/frontend/src/store/playerStore.ts
+++ b/frontend/src/store/playerStore.ts
@@ -29,6 +29,7 @@ interface PlayerState {
   loopEnabled: boolean;
   loopStart: number | null;
   loopEnd: number | null;
+  loopHistory: Array<{ a: number | null; b: number | null }>;
   // EQ
   eqMode: EqMode;
   activeStemForEq: string | null;
@@ -68,6 +69,10 @@ interface PlayerActions {
   setLoopEnabled: (v: boolean) => void;
   setLoopStart: (v: number | null) => void;
   setLoopEnd: (v: number | null) => void;
+  pushLoopHistoryItem: (item: { a: number | null; b: number | null }) => void;
+  removeLoopHistoryItem: (index: number) => void;
+  clearLoopHistory: () => void;
+  setLoopHistory: (items: Array<{ a: number | null; b: number | null }>) => void;
   setEqMode: (mode: EqMode) => void;
   setActiveStemForEq: (stem: string | null) => void;
   setGlobalEqBand: (bandIndex: number, gain: number) => void;
@@ -105,6 +110,7 @@ export const usePlayerStore = create<PlayerState & PlayerActions>()((set) => ({
   loopEnabled: false,
   loopStart: null,
   loopEnd: null,
+  loopHistory: [],
   eqMode: "global",
   activeStemForEq: null,
   globalEq: DEFAULT_EQ_BANDS.map((b) => ({ ...b })),
@@ -149,6 +155,11 @@ export const usePlayerStore = create<PlayerState & PlayerActions>()((set) => ({
   setLoopEnabled: (loopEnabled) => set({ loopEnabled }),
   setLoopStart: (loopStart) => set({ loopStart }),
   setLoopEnd: (loopEnd) => set({ loopEnd }),
+  pushLoopHistoryItem: (item) => set((s) => ({ loopHistory: [item, ...s.loopHistory] })),
+  removeLoopHistoryItem: (index) =>
+    set((s) => ({ loopHistory: s.loopHistory.filter((_, i) => i !== index) })),
+  clearLoopHistory: () => set({ loopHistory: [] }),
+  setLoopHistory: (loopHistory) => set({ loopHistory }),
   setEqMode: (eqMode) => set({ eqMode }),
   setActiveStemForEq: (activeStemForEq) => set({ activeStemForEq }),
   setGlobalEqBand: (bandIndex, gain) =>

--- a/frontend/src/test/components/PlayerSection.test.tsx
+++ b/frontend/src/test/components/PlayerSection.test.tsx
@@ -106,6 +106,7 @@ function resetStore() {
     loopEnabled: false,
     loopStart: null,
     loopEnd: null,
+    loopHistory: [],
     stemVolumes: {},
     stemMuted: {},
   });
@@ -822,6 +823,278 @@ describe("PlayerSection", () => {
       expect(alert.textContent).toMatch(/not available offline/i);
       // Loading indicator must be reset to false.
       expect(usePlayerStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Loop interval history
+  // ---------------------------------------------------------------------------
+
+  describe("loop interval history", () => {
+
+    // ── Mutation operations do not auto-archive ────────────────────────────
+
+    it("Set A does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 50, startOffset: 30, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-a-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("Set B does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 5, loopEnd: 80, startOffset: 60, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-b-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("Shift does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 40, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-shift-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("Clear does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 5, loopEnd: 25, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-clear-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("Clear A does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 15, loopEnd: 60, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-clear-a-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("Clear B does not modify loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 50, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-clear-b-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    // ── Add button ─────────────────────────────────────────────────────────
+
+    it("Add button copies current interval onto the history list", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 50, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-add-btn")!); });
+      const { loopHistory, loopStart, loopEnd } = usePlayerStore.getState();
+      expect(loopHistory).toHaveLength(1);
+      expect(loopHistory[0]).toEqual({ a: 10, b: 50 });
+      // current interval must remain unchanged
+      expect(loopStart).toBe(10);
+      expect(loopEnd).toBe(50);
+    });
+
+    it("Add button with blank current (null A and B) is a no-op", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: false, loopStart: null, loopEnd: null, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-add-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    // ── Restore by clicking a history item ─────────────────────────────────
+
+    it("clicking a history item sets its A/B as the current interval and enables loop", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopEnabled: false,
+          loopStart: 5,
+          loopEnd: 25,
+          loopHistory: [{ a: 30, b: 70 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-item-0 .loop-history-restore")!); });
+      const s = usePlayerStore.getState();
+      expect(s.loopStart).toBe(30);
+      expect(s.loopEnd).toBe(70);
+      expect(s.loopEnabled).toBe(true);
+    });
+
+    it("clicking a history item when playing stops and restarts from restored A", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          isPlaying: true,
+          loopEnabled: true,
+          loopStart: 5,
+          loopEnd: 25,
+          loopHistory: [{ a: 40, b: 80 }],
+        });
+      });
+      const eng = await import("../../audio/engine");
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-item-0 .loop-history-restore")!); });
+      expect(eng.stopSources).toHaveBeenCalled();
+      expect(eng.playAll).toHaveBeenCalled();
+    });
+
+    // ── Remove current interval ─────────────────────────────────────────────
+
+    it("removing current interval blanks A/B and disables loop, leaving history unchanged", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopEnabled: true,
+          loopStart: 5,
+          loopEnd: 25,
+          loopHistory: [{ a: 0, b: 10 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-current .loop-history-remove")!); });
+      const s = usePlayerStore.getState();
+      expect(s.loopStart).toBeNull();
+      expect(s.loopEnd).toBeNull();
+      expect(s.loopEnabled).toBe(false);
+      expect(s.loopHistory).toHaveLength(1); // history unchanged
+    });
+
+    // ── Remove a history item ───────────────────────────────────────────────
+
+    it("removing a history item deletes that entry, leaving current unchanged", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopEnabled: true,
+          loopStart: 5,
+          loopEnd: 25,
+          loopHistory: [{ a: 5, b: 15 }, { a: 0, b: 5 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-item-0 .loop-history-remove")!); });
+      const s = usePlayerStore.getState();
+      expect(s.loopHistory).toHaveLength(1);
+      expect(s.loopHistory[0]).toEqual({ a: 0, b: 5 });
+      expect(s.loopStart).toBe(5);
+      expect(s.loopEnd).toBe(25);
+    });
+
+    // ── Clear all ──────────────────────────────────────────────────────────
+
+    it("Clear all history button empties loopHistory", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopEnabled: true,
+          loopStart: 5,
+          loopEnd: 25,
+          loopHistory: [{ a: 0, b: 10 }, { a: 5, b: 20 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-clear-btn")!); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    // ── Song load ────────────────────────────────────────────────────────────
+
+    it("song load resets loopHistory to empty when no stored history", async () => {
+      // getItem returns null (from beforeEach stub) → empty history
+      usePlayerStore.setState({
+        activeSong: readySong,
+        loopHistory: [{ a: 5, b: 25 }],
+      });
+      await act(async () => { render(<PlayerSection />); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    it("song load restores history from localStorage", async () => {
+      const stored = [{ a: 10, b: 50 }, { a: 20, b: 60 }];
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === "bass-karaoke-player:loop-history:s1") return JSON.stringify(stored);
+        return null;
+      });
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      expect(usePlayerStore.getState().loopHistory).toEqual(stored);
+    });
+
+    it("song load with invalid JSON in localStorage starts with empty history", async () => {
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === "bass-karaoke-player:loop-history:s1") return "not valid json {{";
+        return null;
+      });
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      expect(usePlayerStore.getState().loopHistory).toHaveLength(0);
+    });
+
+    // ── Persistence writes ───────────────────────────────────────────────────
+
+    it("Add button persists the updated history to localStorage", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({ loopEnabled: true, loopStart: 10, loopEnd: 50, loopHistory: [] });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-add-btn")!); });
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "bass-karaoke-player:loop-history:s1",
+        JSON.stringify([{ a: 10, b: 50 }]),
+      );
+    });
+
+    it("removing a history item persists the updated history to localStorage", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopEnabled: true, loopStart: 5, loopEnd: 25,
+          loopHistory: [{ a: 10, b: 50 }, { a: 20, b: 60 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-item-0 .loop-history-remove")!); });
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "bass-karaoke-player:loop-history:s1",
+        JSON.stringify([{ a: 20, b: 60 }]),
+      );
+    });
+
+    it("Clear all persists empty history to localStorage", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          loopHistory: [{ a: 0, b: 10 }, { a: 5, b: 20 }],
+        });
+      });
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-clear-btn")!); });
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "bass-karaoke-player:loop-history:s1",
+        JSON.stringify([]),
+      );
     });
   });
 });

--- a/frontend/src/test/unit/playerStore.test.ts
+++ b/frontend/src/test/unit/playerStore.test.ts
@@ -21,6 +21,7 @@ function resetStore() {
     loopEnabled: false,
     loopStart: null,
     loopEnd: null,
+    loopHistory: [],
     eqMode: "global",
     activeStemForEq: null,
     globalEq: DEFAULT_EQ_BANDS.map((b) => ({ ...b })),
@@ -236,6 +237,48 @@ describe("playerStore", () => {
     it("updates muted state for a single stem", () => {
       usePlayerStore.getState().setStemMuted("drums", true);
       expect(usePlayerStore.getState().stemMuted["drums"]).toBe(true);
+    });
+  });
+
+  describe("loopHistory", () => {
+    it("starts empty", () => {
+      expect(usePlayerStore.getState().loopHistory).toEqual([]);
+    });
+
+    it("pushLoopHistoryItem prepends to the list", () => {
+      usePlayerStore.getState().pushLoopHistoryItem({ a: 10, b: 50 });
+      expect(usePlayerStore.getState().loopHistory).toEqual([{ a: 10, b: 50 }]);
+    });
+
+    it("pushLoopHistoryItem keeps newest entry first", () => {
+      usePlayerStore.getState().pushLoopHistoryItem({ a: 10, b: 50 });
+      usePlayerStore.getState().pushLoopHistoryItem({ a: 20, b: 60 });
+      expect(usePlayerStore.getState().loopHistory[0]).toEqual({ a: 20, b: 60 });
+      expect(usePlayerStore.getState().loopHistory[1]).toEqual({ a: 10, b: 50 });
+    });
+
+    it("removeLoopHistoryItem removes the item at the given index", () => {
+      usePlayerStore.setState({ loopHistory: [{ a: 5, b: 15 }, { a: 0, b: 5 }] });
+      usePlayerStore.getState().removeLoopHistoryItem(0);
+      expect(usePlayerStore.getState().loopHistory).toEqual([{ a: 0, b: 5 }]);
+    });
+
+    it("removeLoopHistoryItem leaves other items untouched", () => {
+      usePlayerStore.setState({ loopHistory: [{ a: 1, b: 2 }, { a: 3, b: 4 }, { a: 5, b: 6 }] });
+      usePlayerStore.getState().removeLoopHistoryItem(1);
+      expect(usePlayerStore.getState().loopHistory).toEqual([{ a: 1, b: 2 }, { a: 5, b: 6 }]);
+    });
+
+    it("clearLoopHistory empties the list", () => {
+      usePlayerStore.setState({ loopHistory: [{ a: 0, b: 10 }, { a: 5, b: 20 }] });
+      usePlayerStore.getState().clearLoopHistory();
+      expect(usePlayerStore.getState().loopHistory).toEqual([]);
+    });
+
+    it("setLoopHistory replaces the list", () => {
+      usePlayerStore.setState({ loopHistory: [{ a: 0, b: 10 }] });
+      usePlayerStore.getState().setLoopHistory([{ a: 30, b: 70 }, { a: 5, b: 15 }]);
+      expect(usePlayerStore.getState().loopHistory).toEqual([{ a: 30, b: 70 }, { a: 5, b: 15 }]);
     });
   });
 });


### PR DESCRIPTION
This pull request adds a new "Loop Interval History" feature to the audio player, allowing users to save, restore, and manage multiple loop intervals per song. The implementation covers UI, state management, and persistence in local storage. The most important changes are grouped below:

**Loop Interval History Feature (UI and Logic):**

* Added a "Loop Interval History" section to the `PlaybackBar` component, including UI for adding the current interval, clearing all saved intervals, displaying the current and saved intervals, restoring a saved interval, and removing intervals. (`frontend/src/components/PlaybackBar.tsx`) [[1]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR21-R25) [[2]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR118-R122) [[3]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR131) [[4]](diffhunk://#diff-a286f67ce16eb6bcf21555bdf6d2b4fe204a2002a685bf1386d168509fc399afR398-R475)
* Implemented handler functions in `PlayerSection` for all loop history actions (add, remove, restore, clear), and wired them to the `PlaybackBar` via props. (`frontend/src/components/PlayerSection.tsx`) [[1]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR99-R102) [[2]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR517-R562) [[3]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR820-R824)

**Persistence and State Management:**

* Added localStorage-based persistence for loop interval history per song using new utility functions, and ensured loop history is loaded when a song is selected. (`frontend/src/components/PlayerSection.tsx`) [[1]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR16-R20) [[2]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR44-R72) [[3]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR700)
* Extended the player store with new state (`loopHistory`) and actions to manage the loop interval history (push, remove, clear, set). (`frontend/src/store/playerStore.ts`) [[1]](diffhunk://#diff-9c2e2704786658fa7ab825cf83de1df3bfba9b339d22797fc36526681be4d391R32) [[2]](diffhunk://#diff-9c2e2704786658fa7ab825cf83de1df3bfba9b339d22797fc36526681be4d391R72-R75) [[3]](diffhunk://#diff-9c2e2704786658fa7ab825cf83de1df3bfba9b339d22797fc36526681be4d391R113) [[4]](diffhunk://#diff-9c2e2704786658fa7ab825cf83de1df3bfba9b339d22797fc36526681be4d391R158-R162)

**Testing Support:**

* Updated test store reset logic to include the new `loopHistory` state. (`frontend/src/test/components/PlayerSection.test.tsx`)## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
