### PR TITLE
feat: clear "Now" interval ony resets times

### DIFF
--- a/frontend/src/components/PlayerSection.tsx
+++ b/frontend/src/components/PlayerSection.tsx
@@ -540,9 +540,10 @@ export function PlayerSection() {
   };
 
   const handleRemoveCurrentInterval = () => {
-    setLoopStart(null);
-    setLoopEnd(null);
-    setLoopEnabled(false);
+    // Reset interval to full song span but keep looping enabled.
+    setLoopStart(0);
+    setLoopEnd(duration);
+    setLoopEnabled(true);
     if (isPlaying) {
       const offset = getCurrentPos();
       eng.stopSources();

--- a/frontend/src/test/components/PlayerSection.test.tsx
+++ b/frontend/src/test/components/PlayerSection.test.tsx
@@ -961,9 +961,10 @@ describe("PlayerSection", () => {
 
     // ── Remove current interval ─────────────────────────────────────────────
 
-    it("removing current interval blanks A/B and disables loop, leaving history unchanged", async () => {
+    it("removing current interval resets A/B to song bounds and keeps loop enabled, leaving history unchanged", async () => {
       usePlayerStore.setState({ activeSong: readySong });
       await act(async () => { render(<PlayerSection />); });
+      // After render, duration is set by getDuration() mock = 100.
       await act(async () => {
         usePlayerStore.setState({
           loopEnabled: true,
@@ -974,10 +975,35 @@ describe("PlayerSection", () => {
       });
       await act(async () => { fireEvent.click(document.querySelector("#loop-history-current .loop-history-remove")!); });
       const s = usePlayerStore.getState();
-      expect(s.loopStart).toBeNull();
-      expect(s.loopEnd).toBeNull();
-      expect(s.loopEnabled).toBe(false);
+      expect(s.loopStart).toBe(0);           // reset to song start
+      expect(s.loopEnd).toBe(100);           // reset to song end (getDuration() = 100)
+      expect(s.loopEnabled).toBe(true);      // loop stays on
       expect(s.loopHistory).toHaveLength(1); // history unchanged
+    });
+
+    it("removing current interval while playing stops sources and restarts playback with loop active", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        usePlayerStore.setState({
+          isPlaying: true,
+          loopEnabled: true,
+          loopStart: 10,
+          loopEnd: 50,
+          loopHistory: [],
+        });
+      });
+      const eng = await import("../../audio/engine");
+      vi.mocked(eng.stopSources).mockClear();
+      vi.mocked(eng.playAll).mockClear();
+      await act(async () => { fireEvent.click(document.querySelector("#loop-history-current .loop-history-remove")!); });
+      expect(eng.stopSources).toHaveBeenCalled();
+      expect(eng.playAll).toHaveBeenCalled();
+      // Loop must still be enabled and span full song after removal
+      const s = usePlayerStore.getState();
+      expect(s.loopEnabled).toBe(true);
+      expect(s.loopStart).toBe(0);
+      expect(s.loopEnd).toBe(100);
     });
 
     // ── Remove a history item ───────────────────────────────────────────────


### PR DESCRIPTION
This pull request updates the logic for removing the current loop interval in the `PlayerSection` component. Instead of disabling looping and clearing the interval, removing the current interval now resets the loop to span the entire song and keeps looping enabled. The changes also update and expand the test suite to reflect and verify this new behavior.

**Player loop interval behavior:**

* Updated `handleRemoveCurrentInterval` in `PlayerSection` to reset the loop to the full song range (`0` to `duration`) and keep looping enabled, instead of disabling the loop and clearing the interval.

**Testing updates:**

* Modified the test "removing current interval" to expect loop start/end to be reset to the song bounds and looping to remain enabled, instead of being cleared/disabled. [[1]](diffhunk://#diff-69d8d7f67b5f5b29f3d7eef0cdbadd42d1d198cb88a4421ab81489952827738bL964-R967) [[2]](diffhunk://#diff-69d8d7f67b5f5b29f3d7eef0cdbadd42d1d198cb88a4421ab81489952827738bL977-R1008)
* Added a new test to verify that removing the current interval while playing stops and restarts playback, with looping still active and spanning the full song.## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
