### PR TITLE
Feat/queued song load button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ npm run build
 
 `npm run build` runs `tsc -b && vite build` — the TypeScript compiler (`tsc`) will catch type errors that would otherwise only surface inside the Docker build.
 
+Then run the end-to-end tests (run from repository root):
+
+```
+uv run pytest e2e/
+```
+
 ### 2. Backend (run from repository root)
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,20 +34,10 @@ Examples:
 
 ## Completing Development Work
 
-Every session of development work must conclude with the following two steps, in order:
-
-### 1. Build the Docker image
+Every session of development work must conclude with a build of the docker image
 
 ```
 time docker build . --tag ghcr.io/dmaticzka/bass-karaoke-player:dev
 ```
 
 Run from the repository root (`/var/home/tzk/co/bass-karaoke-player`).
-
-### 2. Deploy via docker compose
-
-```
-docker compose up
-```
-
-Run from `../heimdal/workloads/bkpdev` (relative to the repository root).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,30 @@ Examples:
 
 ## Completing Development Work
 
-Every session of development work must conclude with a build of the docker image
+Before building the Docker image, run all individual build and test steps first to catch errors quickly without a full Docker build cycle.
+
+### 1. Frontend (run from `frontend/`)
+
+```
+npm test
+npm run build
+```
+
+`npm run build` runs `tsc -b && vite build` — the TypeScript compiler (`tsc`) will catch type errors that would otherwise only surface inside the Docker build.
+
+### 2. Backend (run from repository root)
+
+```
+uv run ruff check backend/
+uv run ruff format --check backend/
+uv run mypy backend/app/ --ignore-missing-imports
+uv run pytest
+```
+
+### 3. Docker image (run from repository root)
+
+Only after all of the above pass:
 
 ```
 time docker build . --tag ghcr.io/dmaticzka/bass-karaoke-player:dev
 ```
-
-Run from the repository root (`/var/home/tzk/co/bass-karaoke-player`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Instructions
+
+## Development Workflow
+
+### Test-Driven Development
+
+Always follow TDD:
+1. Write failing tests that specify the desired behaviour
+2. Verify the tests fail before implementing
+3. Implement the feature until all tests pass
+
+### Feature Branch
+
+Always work on a feature branch. Check the current branch with `git branch` before starting. If on `main` (or `master`), create and switch to a new branch:
+
+```
+git checkout -b feat/<short-description>
+```
+
+### Commit Regularly
+
+Commit after each meaningful unit of work. Use the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<optional scope>): <short description>
+```
+
+Common types: `feat`, `fix`, `refactor`, `test`, `chore`, `docs`.
+
+Examples:
+- `feat(player): add Original audio mode`
+- `fix(versions): correct cache indicator for original bubble`
+- `test(VersionsPicker): add failing tests for original cache indicator`
+
+## Completing Development Work
+
+Every session of development work must conclude with the following two steps, in order:
+
+### 1. Build the Docker image
+
+```
+time docker build . --tag ghcr.io/dmaticzka/bass-karaoke-player:dev
+```
+
+Run from the repository root (`/var/home/tzk/co/bass-karaoke-player`).
+
+### 2. Deploy via docker compose
+
+```
+docker compose up
+```
+
+Run from `../heimdal/workloads/bkpdev` (relative to the repository root).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,16 @@ FRONTEND_DIR = Path(os.getenv("FRONTEND_DIR", "frontend/dist"))
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 ALLOWED_AUDIO_SUFFIXES = {".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac"}
 MAX_UPLOAD_BYTES = 300 * 1024 * 1024  # 300 MB
+
+# MIME types for original audio files served as-is.
+ORIGINAL_AUDIO_CONTENT_TYPES: dict[str, str] = {
+    ".mp3": "audio/mpeg",
+    ".wav": "audio/wav",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+}
 MAX_VERSIONS_GLOBAL = int(os.getenv("MAX_VERSIONS_GLOBAL", "50"))
 # Maximum number of stem-splitting jobs that may run concurrently.
 # Additional uploads are queued (status "queued") until a slot is free.
@@ -497,6 +507,36 @@ def _song_router() -> APIRouter:
         return FileResponse(
             path,
             media_type="audio/mpeg",
+            headers={"Cache-Control": "public, max-age=31536000, immutable"},
+        )
+
+    @router.get(
+        "/songs/{song_id}/original-audio",
+        responses={
+            200: {"content": {"audio/*": {}}},
+            404: {"model": ErrorResponse},
+        },
+    )
+    async def get_original_audio(song_id: str) -> FileResponse:
+        """Stream the original uploaded audio file, regardless of split status.
+
+        Available as soon as the upload completes — before or during stem
+        splitting.  This lets users play the unmodified source file while
+        waiting for the split to finish.
+        """
+        song = storage.load_song(song_id)
+        if song is None:
+            raise HTTPException(status_code=404, detail="Song not found.")
+        path = storage.original_file_path(song_id)
+        if path is None:
+            raise HTTPException(
+                status_code=404, detail="Original audio file not found on disk."
+            )
+        suffix = path.suffix.lower()
+        media_type = ORIGINAL_AUDIO_CONTENT_TYPES.get(suffix, "application/octet-stream")
+        return FileResponse(
+            path,
+            media_type=media_type,
             headers={"Cache-Control": "public, max-age=31536000, immutable"},
         )
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -533,7 +533,9 @@ def _song_router() -> APIRouter:
                 status_code=404, detail="Original audio file not found on disk."
             )
         suffix = path.suffix.lower()
-        media_type = ORIGINAL_AUDIO_CONTENT_TYPES.get(suffix, "application/octet-stream")
+        media_type = ORIGINAL_AUDIO_CONTENT_TYPES.get(
+            suffix, "application/octet-stream"
+        )
         return FileResponse(
             path,
             media_type=media_type,

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -93,6 +93,16 @@ class SongStorage:
         orig_dir.mkdir(parents=True, exist_ok=True)
         return orig_dir / filename
 
+    def original_file_path(self, song_id: str) -> Path | None:
+        """Return the path of the original uploaded audio file, or None if absent."""
+        orig_dir = self.original_dir(song_id)
+        if not orig_dir.exists():
+            return None
+        for f in orig_dir.iterdir():
+            if f.is_file():
+                return f
+        return None
+
     def stem_path(self, song_id: str, stem: StemName) -> Path:
         return self.stems_output_dir(song_id) / f"{stem.value}.mp3"
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -328,7 +328,7 @@ class TestGetOriginalAudio:
         data_dir: Path,
         filename: str = "track.mp3",
         status: SongStatus = SongStatus.READY,
-    ) -> "Song":
+    ) -> Song:
         from backend.app.models import Song
         from backend.app.storage import SongStorage
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -316,6 +316,164 @@ class TestGetStem:
 
 
 # ---------------------------------------------------------------------------
+# Original audio endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGetOriginalAudio:
+    """Tests for GET /api/songs/{song_id}/original-audio."""
+
+    def _make_song_with_original(
+        self,
+        data_dir: Path,
+        filename: str = "track.mp3",
+        status: SongStatus = SongStatus.READY,
+    ) -> "Song":
+        from backend.app.models import Song
+        from backend.app.storage import SongStorage
+
+        storage = SongStorage(data_dir)
+        song = Song(id="orig-song", filename=filename, status=status)
+        storage.save_song(song)
+        orig_path = storage.upload_path(song.id, filename)
+        orig_path.write_bytes(b"\x00" * 32)
+        return song
+
+    def test_get_original_audio_ok(self, client: TestClient, data_dir: Path) -> None:
+        """Returns 200 and the audio bytes for a ready song."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir)
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert resp.content == b"\x00" * 32
+
+    def test_get_original_audio_works_while_splitting(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Returns 200 even when the song status is 'splitting' (not yet ready)."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, status=SongStatus.SPLITTING)
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+
+    def test_get_original_audio_works_while_queued(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Returns 200 when status is 'queued' (upload complete but not split yet)."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, status=SongStatus.QUEUED)
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+
+    def test_get_original_audio_404_song_not_found(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Returns 404 when the song id does not exist."""
+        import backend.app.main as main_module
+
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get("/api/songs/nonexistent/original-audio")
+        assert resp.status_code == 404
+
+    def test_get_original_audio_404_file_missing(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Returns 404 when the original file has been removed from disk."""
+        import backend.app.main as main_module
+        from backend.app.models import Song
+        from backend.app.storage import SongStorage
+
+        storage = SongStorage(data_dir)
+        song = Song(id="no-file-song", filename="gone.mp3", status=SongStatus.READY)
+        storage.save_song(song)
+        # Do NOT write the file — original_dir exists but is empty.
+        storage.original_dir(song.id).mkdir(parents=True, exist_ok=True)
+        main_module.storage = storage
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 404
+
+    def test_get_original_audio_content_type_mp3(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Serves audio/mpeg for .mp3 files."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, filename="track.mp3")
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert "audio/mpeg" in resp.headers["content-type"]
+
+    def test_get_original_audio_content_type_wav(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Serves audio/wav for .wav files."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, filename="track.wav")
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert "audio/wav" in resp.headers["content-type"]
+
+    def test_get_original_audio_content_type_flac(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Serves audio/flac for .flac files."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, filename="track.flac")
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert "audio/flac" in resp.headers["content-type"]
+
+    def test_get_original_audio_content_type_ogg(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Serves audio/ogg for .ogg files."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, filename="track.ogg")
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert "audio/ogg" in resp.headers["content-type"]
+
+    def test_get_original_audio_content_type_m4a(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Serves audio/mp4 for .m4a files."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir, filename="track.m4a")
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        assert "audio/mp4" in resp.headers["content-type"]
+
+    def test_get_original_audio_cache_control_header(
+        self, client: TestClient, data_dir: Path
+    ) -> None:
+        """Sets long-lived immutable Cache-Control header."""
+        import backend.app.main as main_module
+
+        song = self._make_song_with_original(data_dir)
+        main_module.storage = SongStorage(data_dir)
+        resp = client.get(f"/api/songs/{song.id}/original-audio")
+        assert resp.status_code == 200
+        cc = resp.headers.get("cache-control", "")
+        assert "public" in cc
+        assert "immutable" in cc
+
+
+# ---------------------------------------------------------------------------
 # Process stem
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -166,6 +166,38 @@ class TestSongStorage:
         assert reloaded is not None
         assert reloaded.error_message == "processing failed"
 
+    def test_original_file_path_returns_none_when_no_file(
+        self, storage: SongStorage
+    ) -> None:
+        """original_file_path returns None when the original/ dir doesn't exist."""
+        song = storage.create_song("song.mp3")
+        assert storage.original_file_path(song.id) is None
+
+    def test_original_file_path_returns_none_when_dir_empty(
+        self, storage: SongStorage
+    ) -> None:
+        """original_file_path returns None when the original/ dir is empty."""
+        song = storage.create_song("song.mp3")
+        storage.original_dir(song.id).mkdir(parents=True, exist_ok=True)
+        assert storage.original_file_path(song.id) is None
+
+    def test_original_file_path_returns_the_uploaded_file(
+        self, storage: SongStorage
+    ) -> None:
+        """original_file_path returns the path of the uploaded file."""
+        song = storage.create_song("track.mp3")
+        path = storage.upload_path(song.id, "track.mp3")
+        path.write_bytes(b"\x00" * 16)
+        result = storage.original_file_path(song.id)
+        assert result is not None
+        assert result == path
+
+    def test_original_file_path_ignores_non_existent_song(
+        self, storage: SongStorage
+    ) -> None:
+        """original_file_path returns None for a song id that has no directory."""
+        assert storage.original_file_path("nonexistent-id") is None
+
 
 class TestVersionStorage:
     def test_list_versions_empty_no_dir(self, storage: SongStorage) -> None:

--- a/e2e/test_ui.py
+++ b/e2e/test_ui.py
@@ -113,6 +113,11 @@ class TestPlayerSection:
         load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
+        # The player defaults to "Original" mode; switch to Stems so that
+        # stem cards are rendered for tests that rely on them.
+        stems_btn = page.locator(".version-item", has_text="Stems")
+        expect(stems_btn).to_be_visible()
+        stems_btn.click()
         return page
 
     @pytest.fixture()
@@ -139,6 +144,12 @@ class TestPlayerSection:
         load_btn = song_item.locator(".song-load-btn")
         expect(load_btn).to_be_visible()
         load_btn.click()
+        # The player defaults to "Original" mode (original audio URL is not
+        # delayed); switch to Stems so the delayed stem fetches begin and the
+        # UI stays in the loading state for the assertions below.
+        stems_btn = page.locator(".version-item", has_text="Stems")
+        expect(stems_btn).to_be_visible()
+        stems_btn.click()
         return page
 
     def test_player_becomes_visible(self, loaded_player: Page) -> None:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,4 +92,7 @@ export const api = {
 
   processedStemUrl: (songId: string, stem: StemName, pitch: number, tempo: number) =>
     `${API_BASE}/songs/${songId}/stems/${stem}/processed?pitch=${pitch}&tempo=${tempo}`,
+
+  originalAudioUrl: (songId: string) =>
+    `${API_BASE}/songs/${songId}/original-audio`,
 };

--- a/frontend/src/audio/audioCache.ts
+++ b/frontend/src/audio/audioCache.ts
@@ -1,15 +1,15 @@
 /**
- * Stem audio fetch utilities.
+ * Stem and original-audio fetch utilities.
  *
- * The Service Worker (sw.ts) transparently caches stem responses in the
- * `bass-karaoke-stems-v1` Cache Storage bucket using a CacheFirst strategy.
- * No in-memory or manual Cache Storage layer is needed here – the browser's
- * fetch pipeline handles both the in-flight de-duplication and the persistent
- * offline cache.
+ * The Service Worker (sw.ts) transparently caches stem and original-audio
+ * responses in the `bass-karaoke-stems-v1` Cache Storage bucket using a
+ * CacheFirst strategy.  No in-memory or manual Cache Storage layer is needed
+ * here – the browser's fetch pipeline handles both the in-flight
+ * de-duplication and the persistent offline cache.
  *
- * Use {@link fetchWithCache} to load stems; the SW will serve from cache on
+ * Use {@link fetchWithCache} to load audio; the SW will serve from cache on
  * repeat requests and after page reloads.  Use {@link hasCached} to check
- * whether all stem URLs for a given version are already available offline.
+ * whether all audio URLs for a given version are already available offline.
  */
 
 /** Name of the Cache Storage bucket used by the SW for stem audio. */

--- a/frontend/src/audio/engine.ts
+++ b/frontend/src/audio/engine.ts
@@ -13,15 +13,23 @@ export interface StemNode {
   eqBypassed: boolean;
 }
 
+interface OriginalNode {
+  buffer: AudioBuffer;
+  gainNode: GainNode;
+  source: AudioBufferSourceNode | null;
+}
+
 interface Engine {
   ctx: AudioContext | null;
   stemNodes: Partial<Record<StemName, StemNode>>;
+  originalNode: OriginalNode | null;
   seekTimerId: number | null;
 }
 
 const engine: Engine = {
   ctx: null,
   stemNodes: {},
+  originalNode: null,
   seekTimerId: null,
 };
 
@@ -44,10 +52,23 @@ export function clearStemNodes(): void {
 export function _resetForTesting(): void {
   engine.ctx = null;
   engine.stemNodes = {};
+  engine.originalNode = null;
   if (engine.seekTimerId !== null) {
     clearInterval(engine.seekTimerId);
     engine.seekTimerId = null;
   }
+}
+
+export function wireOriginalNode(buffer: AudioBuffer): void {
+  const ctx = getOrCreateCtx();
+  const gainNode = ctx.createGain();
+  gainNode.gain.value = 1.0;
+  gainNode.connect(ctx.destination);
+  engine.originalNode = { buffer, gainNode, source: null };
+}
+
+export function clearOriginalNode(): void {
+  engine.originalNode = null;
 }
 
 function buildEqChain(ctx: AudioContext, bands: EqBand[]): BiquadFilterNode[] {
@@ -157,6 +178,23 @@ export function playAll(
     }
     node.source = source;
   }
+
+  if (engine.originalNode) {
+    const orig = engine.originalNode;
+    const source = ctx.createBufferSource();
+    source.buffer = orig.buffer;
+    source.connect(orig.gainNode);
+    if (loopEnabled && loopStart !== null && loopEnd !== null) {
+      source.loop = true;
+      source.loopStart = loopStart;
+      source.loopEnd = loopEnd;
+      const startFrom = Math.max(loopStart, Math.min(offset, loopEnd));
+      source.start(0, startFrom);
+    } else {
+      source.start(0, offset);
+    }
+    orig.source = source;
+  }
 }
 
 export function stopSources(): void {
@@ -168,6 +206,15 @@ export function stopSources(): void {
       // already stopped
     }
     node.source = null;
+  }
+
+  if (engine.originalNode) {
+    try {
+      engine.originalNode.source?.stop();
+    } catch {
+      // already stopped
+    }
+    engine.originalNode.source = null;
   }
 }
 
@@ -196,5 +243,7 @@ export function getDuration(): number {
   const durations = Object.values(engine.stemNodes)
     .filter(Boolean)
     .map((n) => n!.buffer.duration);
-  return durations.length > 0 ? Math.max(...durations) : 0;
+  if (durations.length > 0) return Math.max(...durations);
+  if (engine.originalNode) return engine.originalNode.buffer.duration;
+  return 0;
 }

--- a/frontend/src/components/PlayerSection.tsx
+++ b/frontend/src/components/PlayerSection.tsx
@@ -15,7 +15,7 @@ const POLL_MS = 2000;
 const LAST_SELECTED_VERSIONS_KEY = "bass-karaoke-player:last-selected-versions";
 const LOOP_HISTORY_KEY_PREFIX = "bass-karaoke-player:loop-history";
 
-type LastSelectedVersion = { pitch: number; tempo: number };
+type LastSelectedVersion = { pitch: number; tempo: number; isOriginal?: boolean };
 type LastSelectedVersionsBySong = Record<string, LastSelectedVersion>;
 type LoopHistoryItem = { a: number | null; b: number | null };
 
@@ -29,10 +29,15 @@ const readLastSelectedVersions = (): LastSelectedVersionsBySong => {
     const result: LastSelectedVersionsBySong = {};
     for (const [songId, value] of Object.entries(parsed as Record<string, unknown>)) {
       if (!value || typeof value !== "object") continue;
-      const pitch = (value as { pitch?: unknown }).pitch;
-      const tempo = (value as { tempo?: unknown }).tempo;
-      if (typeof pitch === "number" && typeof tempo === "number") {
-        result[songId] = { pitch, tempo };
+      const v = value as Record<string, unknown>;
+      if (v.isOriginal === true) {
+        result[songId] = { pitch: 0, tempo: 1.0, isOriginal: true };
+      } else {
+        const pitch = v.pitch;
+        const tempo = v.tempo;
+        if (typeof pitch === "number" && typeof tempo === "number") {
+          result[songId] = { pitch, tempo };
+        }
       }
     }
     return result;
@@ -101,6 +106,8 @@ export function PlayerSection() {
   const clearLoopHistory = usePlayerStore((s) => s.clearLoopHistory);
   const setLoopHistory = usePlayerStore((s) => s.setLoopHistory);
   const activeVersion = usePlayerStore((s) => s.activeVersion);
+  const isOriginalActive = usePlayerStore((s) => s.isOriginalActive);
+  const setIsOriginalActive = usePlayerStore((s) => s.setIsOriginalActive);
   const [stemsCollapsed, setStemsCollapsed] = useState(false);
   const [isPrecalculating, setIsPrecalculating] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -119,10 +126,14 @@ export function PlayerSection() {
     songId: string,
     pitchSemitones: number,
     tempoRatio: number,
+    isOriginal?: boolean,
   ) => {
+    const entry: LastSelectedVersion = isOriginal
+      ? { pitch: 0, tempo: 1.0, isOriginal: true }
+      : { pitch: pitchSemitones, tempo: tempoRatio };
     lastSelectedVersionsRef.current = {
       ...lastSelectedVersionsRef.current,
-      [songId]: { pitch: pitchSemitones, tempo: tempoRatio },
+      [songId]: entry,
     };
     try {
       window.localStorage.setItem(
@@ -164,7 +175,8 @@ export function PlayerSection() {
     versions: Version[],
   ): LastSelectedVersion => {
     const saved = lastSelectedVersionsRef.current[songId];
-    if (!saved) return { pitch: 0, tempo: 1.0 };
+    if (!saved) return { pitch: 0, tempo: 1.0, isOriginal: true };
+    if (saved.isOriginal) return { pitch: 0, tempo: 1.0, isOriginal: true };
 
     const matched = versions.find(
       (v) =>
@@ -192,6 +204,8 @@ export function PlayerSection() {
     const requestId = loadRequestRef.current;
     const ctx = eng.getOrCreateCtx();
     eng.clearStemNodes();
+    eng.clearOriginalNode();
+    setIsOriginalActive(false);
 
     const useProcessed = pitchSemitones !== 0 || tempoRatio !== 1;
 
@@ -265,8 +279,48 @@ export function PlayerSection() {
   };
 
   // -----------------------------------------------------------------------
-  // Versions
+  // Original audio loading
   // -----------------------------------------------------------------------
+  const fetchAndDecodeOriginal = async () => {
+    if (!activeSong) return;
+    const requestId = loadRequestRef.current;
+    const ctx = eng.getOrCreateCtx();
+    const url = api.originalAudioUrl(activeSong.id);
+    const encoded = await audioCache.fetchWithCache(url);
+    if (requestId !== loadRequestRef.current) return;
+    const audioBuffer = await ctx.decodeAudioData(encoded);
+    if (requestId !== loadRequestRef.current) return;
+    eng.clearOriginalNode();
+    eng.wireOriginalNode(audioBuffer);
+    const dur = eng.getDuration();
+    setDuration(dur);
+  };
+
+  const handleSelectOriginal = async () => {
+    if (!activeSong) return;
+    const wasPlaying = isPlayingRef.current;
+    const savedOffset = getCurrentPos();
+    const requestId = beginLoadRequest();
+    stopAll();
+    eng.clearStemNodes();
+    setIsOriginalActive(true);
+    persistLastSelectedVersion(activeSong.id, 0, 1.0, true);
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      await fetchAndDecodeOriginal();
+      if (requestId === loadRequestRef.current && wasPlaying) playAll(savedOffset);
+    } catch (e) {
+      console.error("Load original failed:", e);
+      if (requestId === loadRequestRef.current) {
+        setLoadError((e as Error).message ?? "Failed to load original audio.");
+      }
+    } finally {
+      if (requestId === loadRequestRef.current) setIsLoading(false);
+    }
+  };
+
+
   const fetchVersions = async () => {
     if (!activeSong) return;
     try {
@@ -653,7 +707,9 @@ export function PlayerSection() {
   };
 
   const handleSelectVersion = async (vPitch: number, vTempo: number) => {
+    const s = usePlayerStore.getState();
     if (
+      !s.isOriginalActive &&
       activeVersion.pitch === vPitch &&
       activeVersion.tempo === vTempo
     )
@@ -706,35 +762,49 @@ export function PlayerSection() {
     const requestId = beginLoadRequest();
     setIsLoading(true);
     void (async () => {
-      let targetPitch = 0;
-      let targetTempo = 1.0;
+      let preferred: LastSelectedVersion = { pitch: 0, tempo: 1.0, isOriginal: true };
       try {
         const versionsData = await api.getVersions(activeSong.id);
         if (requestId !== loadRequestRef.current) return;
         applyVersions(versionsData.versions);
-        const preferred = resolvePreferredVersion(activeSong.id, versionsData.versions);
-        targetPitch = preferred.pitch;
-        targetTempo = preferred.tempo;
+        preferred = resolvePreferredVersion(activeSong.id, versionsData.versions);
       } catch {
         if (requestId !== loadRequestRef.current) return;
         stopVersionPolling();
       }
 
       if (requestId !== loadRequestRef.current) return;
-      setPitch(targetPitch);
-      setTempo(Math.round(targetTempo * 100));
-      setActiveVersion(targetPitch, targetTempo);
-      persistLastSelectedVersion(activeSong.id, targetPitch, targetTempo);
 
-      try {
-        await fetchAndDecodeStems(targetPitch, targetTempo);
-      } catch (e) {
-        console.error("Initial stem load failed:", e);
-        if (requestId === loadRequestRef.current) {
-          setLoadError((e as Error).message ?? "Failed to load stems.");
+      if (preferred.isOriginal) {
+        setIsOriginalActive(true);
+        persistLastSelectedVersion(activeSong.id, 0, 1.0, true);
+        try {
+          await fetchAndDecodeOriginal();
+        } catch (e) {
+          console.error("Initial original load failed:", e);
+          if (requestId === loadRequestRef.current) {
+            setLoadError((e as Error).message ?? "Failed to load original audio.");
+          }
+        } finally {
+          if (requestId === loadRequestRef.current) setIsLoading(false);
         }
-      } finally {
-        if (requestId === loadRequestRef.current) setIsLoading(false);
+      } else {
+        const targetPitch = preferred.pitch;
+        const targetTempo = preferred.tempo;
+        setPitch(targetPitch);
+        setTempo(Math.round(targetTempo * 100));
+        setActiveVersion(targetPitch, targetTempo);
+        persistLastSelectedVersion(activeSong.id, targetPitch, targetTempo);
+        try {
+          await fetchAndDecodeStems(targetPitch, targetTempo);
+        } catch (e) {
+          console.error("Initial stem load failed:", e);
+          if (requestId === loadRequestRef.current) {
+            setLoadError((e as Error).message ?? "Failed to load stems.");
+          }
+        } finally {
+          if (requestId === loadRequestRef.current) setIsLoading(false);
+        }
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -779,8 +849,9 @@ export function PlayerSection() {
         </p>
       )}
 
-      <VersionsPicker onSelectVersion={handleSelectVersion} />
+      <VersionsPicker onSelectVersion={handleSelectVersion} onSelectOriginal={handleSelectOriginal} />
 
+      {!isOriginalActive && (
       <div className="stems-section">
         <div
           className="collapsible-header"
@@ -801,6 +872,7 @@ export function PlayerSection() {
           />
         </div>
       </div>
+      )}
 
       <PlaybackBar
         onPlayPause={handlePlayPause}

--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -96,11 +96,11 @@ export function SongList({ onLoadSong }: Props) {
               </span>
 
               <div className="song-actions">
-                {(song.status === "ready" || song.status === "splitting") && (
+                {(song.status === "ready" || song.status === "splitting" || song.status === "queued") && (
                   <button
                     className={[
                       "btn btn-sm btn-primary song-load-btn",
-                      song.status === "splitting" ? "status-splitting" : "",
+                      song.status === "splitting" || song.status === "queued" ? "status-splitting" : "",
                       cachedSongIds.has(song.id) ? "song-cached" : "",
                     ]
                       .filter(Boolean)

--- a/frontend/src/components/SongList.tsx
+++ b/frontend/src/components/SongList.tsx
@@ -105,14 +105,9 @@ export function SongList({ onLoadSong }: Props) {
                     ]
                       .filter(Boolean)
                       .join(" ")}
-                    onClick={song.status === "ready" ? () => onLoadSong(song) : undefined}
-                    disabled={song.status === "splitting"}
+                    onClick={() => onLoadSong(song)}
                   >
-                    {song.status === "splitting"
-                      ? "Splitting…"
-                      : activeSong?.id === song.id
-                        ? "Active"
-                        : "Load"}
+                    {activeSong?.id === song.id ? "Active" : "Load"}
                   </button>
                 )}
                 <button

--- a/frontend/src/components/VersionsPicker.tsx
+++ b/frontend/src/components/VersionsPicker.tsx
@@ -6,19 +6,22 @@ import type { Version } from "../types";
 
 interface Props {
   onSelectVersion: (pitch: number, tempo: number) => Promise<void>;
+  onSelectOriginal?: () => void;
 }
 
-export function VersionsPicker({ onSelectVersion }: Props) {
+export function VersionsPicker({ onSelectVersion, onSelectOriginal }: Props) {
   const versions = usePlayerStore((s) => s.versions);
   const activeVersion = usePlayerStore((s) => s.activeVersion);
   const activeSong = usePlayerStore((s) => s.activeSong);
   const setVersions = usePlayerStore((s) => s.setVersions);
+  const isOriginalActive = usePlayerStore((s) => s.isOriginalActive);
   // Subscribe to isLoading so the component re-renders when stem loading completes
   // and the client-cache indicator reflects the updated SW cache state.
   const isLoading = usePlayerStore((s) => s.isLoading);
 
   // Track which version keys are cached in the SW stem cache.
   const [cachedKeys, setCachedKeys] = useState<Set<string>>(new Set());
+  const [isOriginalCached, setIsOriginalCached] = useState(false);
 
   useEffect(() => {
     if (!activeSong || activeSong.stems.length === 0) {
@@ -50,6 +53,21 @@ export function VersionsPicker({ onSelectVersion }: Props) {
     };
   }, [versions, activeSong, isLoading]);
 
+  useEffect(() => {
+    if (!activeSong) {
+      setIsOriginalCached(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const cached = await hasCached([api.originalAudioUrl(activeSong.id)]);
+      if (!cancelled) setIsOriginalCached(cached);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSong, isLoading]);
+
   const handleDelete = async (ver: Version) => {
     if (!activeSong) return;
     try {
@@ -70,12 +88,26 @@ export function VersionsPicker({ onSelectVersion }: Props) {
     }
   };
 
-  if (versions.length === 0) return null;
+  if (!activeSong) return null;
+
+  const originalBubble = (
+    <li
+      className={["original-item", isOriginalActive ? "active" : "", isOriginalCached ? "version-cached" : ""].filter(Boolean).join(" ")}
+      onClick={() => onSelectOriginal?.()}
+      style={{ cursor: "pointer" }}
+    >
+      <span>Original</span>
+    </li>
+  );
+
+  if (versions.length === 0) {
+    return <ul className="versions-list">{originalBubble}</ul>;
+  }
 
   return (
     <div className="versions-section" id="versions-section">
-      <h3>Versions</h3>
       <ul className="versions-list" id="versions-list">
+        {originalBubble}
         {versions.map((ver) => {
           const pitchStr =
             ver.pitch_semitones > 0
@@ -83,9 +115,10 @@ export function VersionsPicker({ onSelectVersion }: Props) {
               : String(ver.pitch_semitones);
           const tempoStr = `${Math.round(ver.tempo_ratio * 100)}%`;
           const label = ver.is_default
-            ? `Original (${tempoStr})`
+            ? "Stems"
             : `${pitchStr} st, ${tempoStr}`;
           const isActive =
+            !isOriginalActive &&
             activeVersion.pitch === ver.pitch_semitones &&
             activeVersion.tempo === ver.tempo_ratio;
           const clickable = ver.status !== "processing";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -379,7 +379,8 @@ a:hover { text-decoration: underline; }
 }
 .version-item.status-processing { animation: pulse 1.2s ease-in-out infinite; }
 .version-status-badge.status-partial { background: #4a4a4a; color: #ccc; }
-.version-item.version-cached { border-left: 3px solid var(--color-accent); padding-left: calc(0.65rem - 3px); }
+.version-item.version-cached,
+.original-item.version-cached { border-left: 3px solid var(--color-accent); padding-left: calc(0.65rem - 3px); }
 
 /* ---------- Song list load-button states ---------- */
 .song-load-btn.status-splitting { animation: pulse 1.2s ease-in-out infinite; }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -341,7 +341,8 @@ a:hover { text-decoration: underline; }
   flex-wrap: wrap;
   gap: 0.4rem;
 }
-.version-item {
+.version-item,
+.original-item {
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -354,8 +355,10 @@ a:hover { text-decoration: underline; }
   transition: border-color var(--transition), background var(--transition);
   white-space: nowrap;
 }
-.version-item:hover { border-color: var(--color-accent); }
-.version-item.active { border-color: var(--color-accent); background: rgba(255,255,255,0.06); font-weight: 600; }
+.version-item:hover,
+.original-item:hover { border-color: var(--color-accent); }
+.version-item.active,
+.original-item.active { border-color: var(--color-accent); background: rgba(255,255,255,0.06); font-weight: 600; }
 .version-delete-btn {
   background: none;
   border: none;

--- a/frontend/src/store/playerStore.ts
+++ b/frontend/src/store/playerStore.ts
@@ -44,6 +44,8 @@ interface PlayerState {
   uploadStatus: string;
   // Song sort order
   songSortOrder: SongSortOrder;
+  // Original audio mode
+  isOriginalActive: boolean;
 }
 
 interface PlayerActions {
@@ -83,6 +85,7 @@ interface PlayerActions {
   setUploadProgress: (pct: number | null) => void;
   setUploadStatus: (msg: string) => void;
   setSongSortOrder: (order: SongSortOrder) => void;
+  setIsOriginalActive: (v: boolean) => void;
 }
 
 const defaultStemEqFor = (stems: string[]): Record<string, EqBand[]> => {
@@ -120,6 +123,7 @@ export const usePlayerStore = create<PlayerState & PlayerActions>()((set) => ({
   uploadProgress: null,
   uploadStatus: "",
   songSortOrder: "last-used",
+  isOriginalActive: false,
 
   setSongs: (songs) => set({ songs }),
   updateSong: (song) =>
@@ -188,4 +192,5 @@ export const usePlayerStore = create<PlayerState & PlayerActions>()((set) => ({
   setUploadProgress: (uploadProgress) => set({ uploadProgress }),
   setUploadStatus: (uploadStatus) => set({ uploadStatus }),
   setSongSortOrder: (songSortOrder) => set({ songSortOrder }),
+  setIsOriginalActive: (isOriginalActive) => set({ isOriginalActive }),
 }));

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -4,7 +4,8 @@
  *
  * Two cache layers:
  *   bass-karaoke-shell-v1  – precached app shell (HTML, JS, CSS, assets)
- *   bass-karaoke-stems-v1  – runtime-cached stem audio (CacheFirst, survives SW updates)
+ *   bass-karaoke-stems-v1  – runtime-cached stem audio and original audio
+ *                            (CacheFirst, survives SW updates)
  *
  * An additional network-first cache for the song-list API response allows the
  * library page to load offline after a prior online visit.
@@ -28,6 +29,7 @@ import {
 } from "workbox-strategies";
 import { ExpirationPlugin } from "workbox-expiration";
 import { CacheableResponsePlugin } from "workbox-cacheable-response";
+import { isStemsCacheRoute } from "./swRoutes";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -64,13 +66,11 @@ registerRoute(
 );
 
 // ---------------------------------------------------------------------------
-// Runtime caching – stem audio (CacheFirst, cache persists across SW updates)
+// Runtime caching – stem audio + original audio (CacheFirst, persists across SW updates)
 // ---------------------------------------------------------------------------
 
 registerRoute(
-  ({ url }) =>
-    url.pathname.startsWith("/api/songs/") &&
-    url.pathname.includes("/stems/"),
+  ({ url }) => isStemsCacheRoute(url.pathname),
   new CacheFirst({
     cacheName: "bass-karaoke-stems-v1",
     plugins: [

--- a/frontend/src/swRoutes.ts
+++ b/frontend/src/swRoutes.ts
@@ -1,0 +1,22 @@
+/**
+ * URL-matching predicates for Service Worker route registration.
+ *
+ * Exported as pure functions so they can be unit-tested independently of the
+ * SW environment.
+ */
+
+/**
+ * Returns true for URLs that should be served with a CacheFirst strategy and
+ * stored in the `bass-karaoke-stems-v1` cache bucket.
+ *
+ * This covers:
+ *   - Stem audio:          /api/songs/{id}/stems/{stem}
+ *   - Processed stems:     /api/songs/{id}/stems/{stem}/processed
+ *   - Original audio:      /api/songs/{id}/original-audio
+ */
+export function isStemsCacheRoute(pathname: string): boolean {
+  return (
+    pathname.startsWith("/api/songs/") &&
+    (pathname.includes("/stems/") || pathname.endsWith("/original-audio"))
+  );
+}

--- a/frontend/src/test/components/App.test.tsx
+++ b/frontend/src/test/components/App.test.tsx
@@ -16,6 +16,7 @@ vi.mock("../../api/client", () => ({
     processStem: vi.fn(),
     stemUrl: vi.fn((id: string, stem: string) => `/api/songs/${id}/stems/${stem}`),
     processedStemUrl: vi.fn(),
+    originalAudioUrl: vi.fn((id: string) => `/api/songs/${id}/original-audio`),
   },
 }));
 

--- a/frontend/src/test/components/PlayerSection.test.tsx
+++ b/frontend/src/test/components/PlayerSection.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../api/client", () => ({
       (id: string, stem: string, p: number, t: number) =>
         `/api/songs/${id}/stems/${stem}/processed?pitch=${p}&tempo=${t}`,
     ),
+    originalAudioUrl: vi.fn((id: string) => `/api/songs/${id}/original-audio`),
   },
 }));
 
@@ -55,6 +56,8 @@ vi.mock("../../audio/engine", () => ({
   })),
   clearStemNodes: vi.fn(),
   wireStemNode: vi.fn(),
+  wireOriginalNode: vi.fn(),
+  clearOriginalNode: vi.fn(),
   getDuration: vi.fn(() => 100),
   playAll: vi.fn(),
   stopSources: vi.fn(),
@@ -109,6 +112,7 @@ function resetStore() {
     loopHistory: [],
     stemVolumes: {},
     stemMuted: {},
+    isOriginalActive: false,
   });
 }
 
@@ -119,8 +123,14 @@ beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
     arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
   }));
+  // Default: song "s1" has a saved stems preference so existing tests start in
+  // stems mode. Tests that need Original mode or a clean slate set their own mock.
   vi.stubGlobal("localStorage", {
-    getItem: vi.fn(() => null),
+    getItem: vi.fn((key: string) => {
+      if (key === "bass-karaoke-player:last-selected-versions")
+        return JSON.stringify({ s1: { pitch: 0, tempo: 1.0 } });
+      return null;
+    }),
     setItem: vi.fn(),
     removeItem: vi.fn(),
   });
@@ -1123,4 +1133,100 @@ describe("PlayerSection", () => {
       );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Original audio mode
+  // ---------------------------------------------------------------------------
+
+  describe("Original audio mode", () => {
+    it("GlobalControls is rendered even when isOriginalActive is true", async () => {
+      // Original preference loaded — GlobalControls should still be present.
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === "bass-karaoke-player:last-selected-versions")
+          return JSON.stringify({ s1: { isOriginal: true } });
+        return null;
+      });
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      expect(screen.queryByRole("slider", { name: "Pitch in semitones" })).toBeInTheDocument();
+    });
+
+    it("StemsStack is not rendered when isOriginalActive is true", async () => {
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === "bass-karaoke-player:last-selected-versions")
+          return JSON.stringify({ s1: { isOriginal: true } });
+        return null;
+      });
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      expect(document.querySelectorAll(".stem-card")).toHaveLength(0);
+    });
+
+    it("clicking the Original bubble sets isOriginalActive to true", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        fireEvent.click(document.querySelector(".original-item")!);
+      });
+      expect(usePlayerStore.getState().isOriginalActive).toBe(true);
+    });
+
+    it("clicking the Original bubble fetches the original audio URL", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      vi.mocked(audioCache.fetchWithCache).mockClear();
+      await act(async () => {
+        fireEvent.click(document.querySelector(".original-item")!);
+      });
+      expect(vi.mocked(audioCache.fetchWithCache)).toHaveBeenCalledWith(
+        expect.stringContaining("/original-audio"),
+      );
+    });
+
+    it("song load with no saved preference defaults to Original mode", async () => {
+      const newSong = { ...readySong, id: "brand-new-song" };
+      // No entry for "brand-new-song" in localStorage.
+      vi.mocked(localStorage.getItem).mockReturnValue(
+        JSON.stringify({ s1: { pitch: 0, tempo: 1.0 } }),
+      );
+      vi.mocked(api.getVersions).mockResolvedValue({ versions: [] });
+      usePlayerStore.setState({ activeSong: newSong });
+      await act(async () => { render(<PlayerSection />); });
+      expect(usePlayerStore.getState().isOriginalActive).toBe(true);
+    });
+
+    it("Original selection is persisted to localStorage", async () => {
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      await act(async () => {
+        fireEvent.click(document.querySelector(".original-item")!);
+      });
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "bass-karaoke-player:last-selected-versions",
+        expect.stringContaining('"isOriginal":true'),
+      );
+    });
+
+    it("selecting a stem version when in Original mode sets isOriginalActive to false", async () => {
+      vi.mocked(localStorage.getItem).mockImplementation((key: string) => {
+        if (key === "bass-karaoke-player:last-selected-versions")
+          return JSON.stringify({ s1: { isOriginal: true } });
+        return null;
+      });
+      usePlayerStore.setState({ activeSong: readySong });
+      await act(async () => { render(<PlayerSection />); });
+      // Add a version and click it to switch away from Original
+      await act(async () => {
+        usePlayerStore.setState({
+          versions: [{ pitch_semitones: 0, tempo_ratio: 1.0, is_default: true, status: "ready" }],
+        });
+      });
+      const versionItem = document.querySelector(".version-item");
+      if (versionItem) {
+        await act(async () => { fireEvent.click(versionItem); });
+        expect(usePlayerStore.getState().isOriginalActive).toBe(false);
+      }
+    });
+  });
 });
+

--- a/frontend/src/test/components/SongList.test.tsx
+++ b/frontend/src/test/components/SongList.test.tsx
@@ -73,12 +73,12 @@ describe("SongList", () => {
     expect(document.querySelector(".song-status-badge")).not.toBeInTheDocument();
   });
 
-  it("shows disabled 'Splitting…' button for splitting song", () => {
+  it("shows enabled 'Load' button for splitting song", () => {
     resetStore([splittingSong]);
     render(<SongList onLoadSong={vi.fn()} />);
-    const btn = screen.getByText("Splitting…");
+    const btn = screen.getByText("Load");
     expect(btn).toBeInTheDocument();
-    expect(btn).toBeDisabled();
+    expect(btn).not.toBeDisabled();
   });
 
   it("splitting button has status-splitting class (pulsates)", () => {
@@ -93,18 +93,26 @@ describe("SongList", () => {
     expect(document.querySelector(".song-load-btn")).not.toBeInTheDocument();
   });
 
-  it("shows Load button only for ready songs", () => {
+  it("shows Load button for both ready and splitting songs", () => {
     resetStore([readySong, splittingSong]);
     render(<SongList onLoadSong={vi.fn()} />);
-    expect(screen.getAllByText("Load")).toHaveLength(1);
+    expect(screen.getAllByText("Load")).toHaveLength(2);
   });
 
-  it("calls onLoadSong with the song when Load is clicked", () => {
+  it("calls onLoadSong with the song when Load is clicked for a ready song", () => {
     const onLoadSong = vi.fn();
     resetStore([readySong]);
     render(<SongList onLoadSong={onLoadSong} />);
     fireEvent.click(screen.getByText("Load"));
     expect(onLoadSong).toHaveBeenCalledWith(readySong);
+  });
+
+  it("calls onLoadSong with the song when Load is clicked for a splitting song", () => {
+    const onLoadSong = vi.fn();
+    resetStore([splittingSong]);
+    render(<SongList onLoadSong={onLoadSong} />);
+    fireEvent.click(screen.getByText("Load"));
+    expect(onLoadSong).toHaveBeenCalledWith(splittingSong);
   });
 
   it("marks active song row with 'active' class", () => {

--- a/frontend/src/test/components/SongList.test.tsx
+++ b/frontend/src/test/components/SongList.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../api/client", () => ({
     deleteSong: vi.fn().mockResolvedValue(undefined),
     getSongs: vi.fn().mockResolvedValue({ songs: [] }),
     stemUrl: vi.fn().mockImplementation((id: string, stem: string) => `/api/songs/${id}/stems/${stem}`),
+    originalAudioUrl: vi.fn().mockImplementation((id: string) => `/api/songs/${id}/original-audio`),
   },
 }));
 

--- a/frontend/src/test/components/SongList.test.tsx
+++ b/frontend/src/test/components/SongList.test.tsx
@@ -36,6 +36,15 @@ const splittingSong: Song = {
   stems: [],
 };
 
+const queuedSong: Song = {
+  id: "s4",
+  filename: "queued.mp3",
+  artist: "Queued Artist",
+  title: "Queued Title",
+  status: "queued",
+  stems: [],
+};
+
 const errorSong: Song = {
   id: "s3",
   filename: "error_song.mp3",
@@ -191,5 +200,33 @@ describe("SongList", () => {
     });
     expect(vi.mocked(api.stemUrl)).toHaveBeenCalledWith("s1", "vocals");
     expect(vi.mocked(api.stemUrl)).toHaveBeenCalledWith("s1", "bass");
+  });
+
+  it("shows enabled 'Load' button for queued song", () => {
+    resetStore([queuedSong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    const btn = screen.getByText("Load");
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it("queued button has status-splitting class (pulsates)", () => {
+    resetStore([queuedSong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    expect(document.querySelector(".song-load-btn.status-splitting")).toBeInTheDocument();
+  });
+
+  it("calls onLoadSong with the song when Load is clicked for a queued song", () => {
+    const onLoadSong = vi.fn();
+    resetStore([queuedSong]);
+    render(<SongList onLoadSong={onLoadSong} />);
+    fireEvent.click(screen.getByText("Load"));
+    expect(onLoadSong).toHaveBeenCalledWith(queuedSong);
+  });
+
+  it("shows Load button for ready, splitting, and queued songs", () => {
+    resetStore([readySong, splittingSong, queuedSong]);
+    render(<SongList onLoadSong={vi.fn()} />);
+    expect(screen.getAllByText("Load")).toHaveLength(3);
   });
 });

--- a/frontend/src/test/components/VersionsPicker.test.tsx
+++ b/frontend/src/test/components/VersionsPicker.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../api/client", () => ({
       (_id: string, stem: string, pitch: number, tempo: number) =>
         `/api/songs/s1/stems/${stem}/processed?pitch=${pitch}&tempo=${tempo}`,
     ),
+    originalAudioUrl: vi.fn().mockImplementation((id: string) => `/api/songs/${id}/original-audio`),
   },
 }));
 
@@ -41,11 +42,12 @@ const processingVersion: Version = {
   status: "processing",
 };
 
-function resetStore(versions: Version[] = [], activePitch = 0, activeTempo = 1.0) {
+function resetStore(versions: Version[] = [], activePitch = 0, activeTempo = 1.0, isOriginalActive = false) {
   usePlayerStore.setState({
     versions,
     activeVersion: { pitch: activePitch, tempo: activeTempo },
     activeSong: { id: "s1", filename: "test.mp3", artist: null, title: null, status: "ready", stems: [] },
+    isOriginalActive,
   });
 }
 
@@ -60,6 +62,31 @@ describe("VersionsPicker", () => {
     expect(document.querySelector("#versions-section")).not.toBeInTheDocument();
   });
 
+  it("renders an Original bubble even when versions list is empty", () => {
+    render(<VersionsPicker onSelectVersion={vi.fn()} />);
+    expect(document.querySelector(".original-item")).toBeInTheDocument();
+  });
+
+  it("Original bubble has active class when isOriginalActive is true", () => {
+    resetStore([], 0, 1.0, true);
+    render(<VersionsPicker onSelectVersion={vi.fn()} />);
+    expect(document.querySelector(".original-item.active")).toBeInTheDocument();
+  });
+
+  it("Original bubble does not have active class when isOriginalActive is false", () => {
+    resetStore([], 0, 1.0, false);
+    render(<VersionsPicker onSelectVersion={vi.fn()} />);
+    expect(document.querySelector(".original-item")).toBeInTheDocument();
+    expect(document.querySelector(".original-item.active")).not.toBeInTheDocument();
+  });
+
+  it("clicking the Original bubble calls onSelectOriginal", () => {
+    const onSelectOriginal = vi.fn();
+    render(<VersionsPicker onSelectVersion={vi.fn()} onSelectOriginal={onSelectOriginal} />);
+    fireEvent.click(screen.getByText("Original"));
+    expect(onSelectOriginal).toHaveBeenCalledTimes(1);
+  });
+
   it("renders a list item per version", () => {
     resetStore([defaultVersion, customVersion]);
     render(<VersionsPicker onSelectVersion={vi.fn()} />);
@@ -70,6 +97,12 @@ describe("VersionsPicker", () => {
     resetStore([defaultVersion]);
     render(<VersionsPicker onSelectVersion={vi.fn()} />);
     expect(screen.getByText(/Original/)).toBeInTheDocument();
+  });
+
+  it("shows 'Stems' label for the default version in the versions list", () => {
+    resetStore([defaultVersion]);
+    render(<VersionsPicker onSelectVersion={vi.fn()} />);
+    expect(screen.getByText("Stems")).toBeInTheDocument();
   });
 
   it("shows pitch and tempo label for non-default version", () => {
@@ -248,6 +281,27 @@ describe("VersionsPicker", () => {
         await Promise.resolve();
       });
       expect(document.querySelector(".version-item.version-cached")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Original bubble cache indicator", () => {
+    it("adds version-cached class to Original bubble when original audio is cached", async () => {
+      const audioCache = await import("../../audio/audioCache");
+      vi.mocked(audioCache.hasCached).mockResolvedValue(true);
+      resetStore();
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      await waitFor(() => {
+        expect(document.querySelector(".original-item.version-cached")).toBeInTheDocument();
+      });
+    });
+
+    it("does not add version-cached class to Original bubble when original audio is not cached", async () => {
+      const audioCache = await import("../../audio/audioCache");
+      vi.mocked(audioCache.hasCached).mockResolvedValue(false);
+      resetStore();
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      await act(async () => { await Promise.resolve(); });
+      expect(document.querySelector(".original-item.version-cached")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/test/unit/client.test.ts
+++ b/frontend/src/test/unit/client.test.ts
@@ -176,6 +176,12 @@ describe("api.processedStemUrl", () => {
   });
 });
 
+describe("api.originalAudioUrl", () => {
+  it("returns the correct URL for the original audio endpoint", () => {
+    expect(api.originalAudioUrl("s1")).toBe("/api/songs/s1/original-audio");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // uploadSong (XHR-based)
 // ---------------------------------------------------------------------------

--- a/frontend/src/test/unit/engine.test.ts
+++ b/frontend/src/test/unit/engine.test.ts
@@ -309,3 +309,81 @@ describe("currentTime", () => {
     expect(typeof t).toBe("number");
   });
 });
+
+// ---------------------------------------------------------------------------
+// wireOriginalNode / clearOriginalNode
+// ---------------------------------------------------------------------------
+
+describe("wireOriginalNode", () => {
+  it("stores the buffer and allows getDuration to return its duration", () => {
+    eng.getOrCreateCtx();
+    const buf = makeAudioBuffer(120);
+    eng.wireOriginalNode(buf);
+    expect(eng.getDuration()).toBe(120);
+  });
+
+  it("connects to AudioContext destination", () => {
+    eng.getOrCreateCtx();
+    const buf = makeAudioBuffer(60);
+    eng.wireOriginalNode(buf);
+    // The gain node created for original should have connected to destination.
+    expect(mockCtx.createGain).toHaveBeenCalled();
+  });
+
+  it("replaces any existing original buffer when called again", () => {
+    eng.getOrCreateCtx();
+    eng.wireOriginalNode(makeAudioBuffer(10));
+    eng.wireOriginalNode(makeAudioBuffer(99));
+    expect(eng.getDuration()).toBe(99);
+  });
+
+  it("getDuration prefers stems over original when both are present", () => {
+    eng.getOrCreateCtx();
+    eng.wireOriginalNode(makeAudioBuffer(200));
+    eng.wireStemNode("bass", makeAudioBuffer(45), 1.0, flatBands);
+    // stems win because getDuration reads from stemNodes first
+    expect(eng.getDuration()).toBe(45);
+  });
+});
+
+describe("clearOriginalNode", () => {
+  it("removes the original buffer so getDuration returns 0", () => {
+    eng.getOrCreateCtx();
+    eng.wireOriginalNode(makeAudioBuffer(80));
+    eng.clearOriginalNode();
+    expect(eng.getDuration()).toBe(0);
+  });
+
+  it("is a no-op when no original node exists", () => {
+    expect(() => eng.clearOriginalNode()).not.toThrow();
+  });
+});
+
+describe("playAll with original node", () => {
+  it("starts the original source when no stems are wired", () => {
+    eng.getOrCreateCtx();
+    const buf = makeAudioBuffer(60);
+    eng.wireOriginalNode(buf);
+    eng.playAll(5, false, null, null);
+    // A BufferSource should have been created and started.
+    expect(mockCtx.createBufferSource).toHaveBeenCalled();
+  });
+});
+
+describe("stopSources with original node", () => {
+  it("stops the original source without throwing", () => {
+    eng.getOrCreateCtx();
+    eng.wireOriginalNode(makeAudioBuffer(60));
+    eng.playAll(0, false, null, null);
+    expect(() => eng.stopSources()).not.toThrow();
+  });
+});
+
+describe("_resetForTesting clears original node", () => {
+  it("getDuration returns 0 after reset even if original was wired", () => {
+    eng.getOrCreateCtx();
+    eng.wireOriginalNode(makeAudioBuffer(50));
+    eng._resetForTesting();
+    expect(eng.getDuration()).toBe(0);
+  });
+});

--- a/frontend/src/test/unit/playerStore.test.ts
+++ b/frontend/src/test/unit/playerStore.test.ts
@@ -31,6 +31,7 @@ function resetStore() {
     uploadProgress: null,
     uploadStatus: "",
     songSortOrder: "last-used",
+    isOriginalActive: false,
   });
 }
 
@@ -252,6 +253,23 @@ describe("playerStore", () => {
     it("setServerConfig replaces config", () => {
       usePlayerStore.getState().setServerConfig({ max_versions_global: 10 });
       expect(usePlayerStore.getState().serverConfig.max_versions_global).toBe(10);
+    });
+  });
+
+  describe("isOriginalActive", () => {
+    it("defaults to false", () => {
+      expect(usePlayerStore.getState().isOriginalActive).toBe(false);
+    });
+
+    it("setIsOriginalActive sets to true", () => {
+      usePlayerStore.getState().setIsOriginalActive(true);
+      expect(usePlayerStore.getState().isOriginalActive).toBe(true);
+    });
+
+    it("setIsOriginalActive sets to false", () => {
+      usePlayerStore.setState({ isOriginalActive: true });
+      usePlayerStore.getState().setIsOriginalActive(false);
+      expect(usePlayerStore.getState().isOriginalActive).toBe(false);
     });
   });
 

--- a/frontend/src/test/unit/swRoutes.test.ts
+++ b/frontend/src/test/unit/swRoutes.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { isStemsCacheRoute } from "../../swRoutes";
+
+describe("isStemsCacheRoute", () => {
+  // --- URLs that must be cached in bass-karaoke-stems-v1 ---
+
+  it("matches default stem URLs", () => {
+    expect(isStemsCacheRoute("/api/songs/abc/stems/bass")).toBe(true);
+    expect(isStemsCacheRoute("/api/songs/abc/stems/drums")).toBe(true);
+    expect(isStemsCacheRoute("/api/songs/abc/stems/vocals")).toBe(true);
+    expect(isStemsCacheRoute("/api/songs/abc/stems/other")).toBe(true);
+  });
+
+  it("matches processed stem URLs", () => {
+    expect(
+      isStemsCacheRoute("/api/songs/abc/stems/bass/processed?pitch=3&tempo=0.9"),
+    ).toBe(true);
+  });
+
+  it("matches original-audio URLs", () => {
+    expect(isStemsCacheRoute("/api/songs/abc/original-audio")).toBe(true);
+  });
+
+  // --- URLs that must NOT be captured by this route ---
+
+  it("does not match the song-list endpoint", () => {
+    expect(isStemsCacheRoute("/api/songs")).toBe(false);
+  });
+
+  it("does not match individual song metadata endpoints", () => {
+    expect(isStemsCacheRoute("/api/songs/abc")).toBe(false);
+  });
+
+  it("does not match the versions endpoint", () => {
+    expect(isStemsCacheRoute("/api/songs/abc/versions")).toBe(false);
+  });
+
+  it("does not match unrelated API paths", () => {
+    expect(isStemsCacheRoute("/api/config")).toBe(false);
+    expect(isStemsCacheRoute("/api/health")).toBe(false);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,7 +2,7 @@
 
 export type StemName = "drums" | "bass" | "vocals" | "other";
 
-export type SongStatus = "uploaded" | "splitting" | "ready" | "error";
+export type SongStatus = "uploaded" | "queued" | "splitting" | "ready" | "error";
 
 // "processing" is a frontend-only optimistic status (not in VersionStatus enum)
 export type VersionStatus = "ready" | "partial" | "missing" | "processing";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.11.12"
+required-version = ">=0.11.8"
 package = false
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dev = [
 
 [tool.uv]
 # renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-required-version = "0.11.8"
+required-version = "0.11.12"
 package = false
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,7 @@ dev = [
 ]
 
 [tool.uv]
-# renovate: datasource=docker depName=ghcr.io/astral-sh/uv
-required-version = "0.11.12"
+required-version = ">=0.11.12"
 package = false
 
 [tool.pytest.ini_options]

--- a/renovate.json
+++ b/renovate.json
@@ -9,20 +9,6 @@
   "lockFileMaintenance": {
     "enabled": true,
   },
-  "customManagers": [
-    {
-      "description": "Track uv required-version in pyproject.toml as the same package pinned in the Dockerfile",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^pyproject\\.toml$/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=docker depName=(?<depName>[^\\n]+)\\nrequired-version = \"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver"
-    }
-  ],
   "packageRules": [
     {
       "description": "Combine all GitHub Actions updates into a single PR",
@@ -35,7 +21,7 @@
       "groupName": "Python backend dependencies"
     },
     {
-      "description": "Group uv version updates in Dockerfile and pyproject.toml into a single PR",
+      "description": "Group uv version updates in Dockerfile into a single PR",
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],
       "groupName": "uv"
     }


### PR DESCRIPTION
This pull request introduces support for streaming and playing the original uploaded audio file for a song, regardless of stem-splitting status. It adds a new backend API endpoint to serve the original audio, updates storage utilities, extends frontend audio engine logic to handle original audio, and updates the player UI and local storage logic to track and play the original audio version. Comprehensive tests are included for both backend and frontend changes.

**Backend: Original Audio Endpoint and Storage**
- Added a new API route `/songs/{song_id}/original-audio` to stream the original uploaded audio file as soon as the upload completes, with correct MIME types and cache headers.
- Implemented `original_file_path` in `SongStorage` to locate the original audio file or return `None` if missing, with corresponding unit tests. [[1]](diffhunk://#diff-d16e9f754e6de2df7bfc99bdb074e879d3991a15aa4c5e6e41cabd7eb85664dbR96-R105) [[2]](diffhunk://#diff-7a3924d6af8b340109d5f78eaa8003843f0912d3c62c182cbf92875cffbb7d2dR169-R200)
- Defined a mapping of file extensions to audio MIME types for accurate content serving.
- Added detailed API tests covering success, error, and content-type scenarios for the new endpoint.

**Frontend: Audio Engine and API Integration**
- Extended the audio engine (`engine.ts`) to support loading, playing, and stopping the original audio file alongside stems, and to report its duration. [[1]](diffhunk://#diff-afe43cba13edca9f883139a7dd119ddab1551abbc8d8976657a3355a2b2817f7R16-R32) [[2]](diffhunk://#diff-afe43cba13edca9f883139a7dd119ddab1551abbc8d8976657a3355a2b2817f7R55-R73) [[3]](diffhunk://#diff-afe43cba13edca9f883139a7dd119ddab1551abbc8d8976657a3355a2b2817f7R181-R197) [[4]](diffhunk://#diff-afe43cba13edca9f883139a7dd119ddab1551abbc8d8976657a3355a2b2817f7R210-R218) [[5]](diffhunk://#diff-afe43cba13edca9f883139a7dd119ddab1551abbc8d8976657a3355a2b2817f7L199-R248)
- Added `originalAudioUrl` to the API client for fetching the original audio.
- Updated audio cache utilities documentation to include original audio.

**Frontend: Player UI and State**
- Modified the player section to track and persist whether the original audio is active, using an updated `LastSelectedVersion` type and local storage logic. [[1]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfL18-R18) [[2]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfL32-R42) [[3]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR109-R110) [[4]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR129-R136) [[5]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfL167-R179)

**Documentation**
- Added `AGENTS.md` with clear development workflow, TDD practices, and build/test instructions.## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
