### PR TITLE
Feat/layout

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Pre-commit hook: runs frontend and backend checks before every commit.
+# Install by running: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "--- pre-commit: frontend tests ---"
+(cd "$REPO_ROOT/frontend" && npm test -- --run)
+
+echo "--- pre-commit: frontend build (type-check) ---"
+(cd "$REPO_ROOT/frontend" && npm run build)
+
+echo "--- pre-commit: ruff check ---"
+uv run ruff check backend/
+
+echo "--- pre-commit: ruff format check ---"
+uv run ruff format --check backend/
+
+echo "--- pre-commit: mypy ---"
+uv run mypy backend/app/ --ignore-missing-imports
+
+echo "--- pre-commit: pytest ---"
+PYTHONPATH=. uv run pytest
+
+echo "--- pre-commit: all checks passed ---"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,35 +34,11 @@ Examples:
 
 ## Completing Development Work
 
-Before building the Docker image, run all individual build and test steps first to catch errors quickly without a full Docker build cycle.
+Frontend tests, frontend build (type-check), ruff, mypy, and pytest are enforced automatically by the pre-commit hook in `.githooks/pre-commit`. The hook is activated via `git config core.hooksPath .githooks` (already set in this repo).
 
-### 1. Frontend (run from `frontend/`)
+### Docker image (run from repository root)
 
-```
-npm test
-npm run build
-```
-
-`npm run build` runs `tsc -b && vite build` — the TypeScript compiler (`tsc`) will catch type errors that would otherwise only surface inside the Docker build.
-
-Then run the end-to-end tests (run from repository root):
-
-```
-uv run pytest e2e/
-```
-
-### 2. Backend (run from repository root)
-
-```
-uv run ruff check backend/
-uv run ruff format --check backend/
-uv run mypy backend/app/ --ignore-missing-imports
-uv run pytest
-```
-
-### 3. Docker image (run from repository root)
-
-Only after all of the above pass:
+Only after all checks pass:
 
 ```
 time docker build . --tag ghcr.io/dmaticzka/bass-karaoke-player:dev

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Interactive API docs are available at `http://localhost:8000/docs`.
 # Install dev dependencies
 uv sync --group dev
 
+# Activate the pre-commit hook (runs frontend tests, build, ruff, mypy, pytest on every commit)
+git config core.hooksPath .githooks
+
 # Run tests
 uv run pytest backend/tests/ -v
 

--- a/frontend/src/components/PlaybackBar.tsx
+++ b/frontend/src/components/PlaybackBar.tsx
@@ -239,6 +239,7 @@ export function PlaybackBar({
       </div>
       </div>
 
+      <h3 className="sub-section-heading">AB Loop</h3>
       <div className="loop-controls" id="loop-controls">
         <button
           id="loop-toggle-btn"
@@ -399,7 +400,7 @@ export function PlaybackBar({
       {/* Loop interval history */}
       <div className="loop-history" id="loop-history">
         <div className="loop-history-header">
-          <span className="loop-history-title">Intervals</span>
+          <span className="loop-history-title">Loop Intervals</span>
           <div className="loop-history-header-actions">
             <button
               className="btn btn-xs btn-secondary"

--- a/frontend/src/components/PlaybackBar.tsx
+++ b/frontend/src/components/PlaybackBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { LoaderCircle, Pause, Play, SkipBack, Square } from "lucide-react";
 import { usePlayerStore } from "../store/playerStore";
 
@@ -136,6 +137,8 @@ export function PlaybackBar({
   const effectiveA = loopStart ?? 0;
   const effectiveB = loopEnd ?? duration;
 
+  const [loopCollapsed, setLoopCollapsed] = useState(false);
+
 
   return (
     <div className="playback-controls">
@@ -239,7 +242,19 @@ export function PlaybackBar({
       </div>
       </div>
 
-      <h3 className="sub-section-heading">AB Loop</h3>
+      <div
+        className="collapsible-header"
+        onClick={() => setLoopCollapsed(!loopCollapsed)}
+      >
+        <h3 className="sub-section-heading">AB Loop</h3>
+        <button
+          className="collapsible-toggle"
+          aria-label={loopCollapsed ? "Expand AB loop" : "Collapse AB loop"}
+        >
+          <span className={`chevron${loopCollapsed ? " collapsed" : ""}`}>▼</span>
+        </button>
+      </div>
+      <div className={`collapsible-body ${loopCollapsed ? "collapsed" : "expanded"}`}>
       <div className="loop-controls" id="loop-controls">
         <button
           id="loop-toggle-btn"
@@ -474,6 +489,7 @@ export function PlaybackBar({
           </div>
         ))}
       </div>
+      </div>{/* collapsible-body */}
     </div>
   );
 }

--- a/frontend/src/components/PlayerSection.tsx
+++ b/frontend/src/components/PlayerSection.tsx
@@ -109,6 +109,7 @@ export function PlayerSection() {
   const isOriginalActive = usePlayerStore((s) => s.isOriginalActive);
   const setIsOriginalActive = usePlayerStore((s) => s.setIsOriginalActive);
   const [stemsCollapsed, setStemsCollapsed] = useState(false);
+  const [controlsCollapsed, setControlsCollapsed] = useState(false);
   const [isPrecalculating, setIsPrecalculating] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -836,12 +837,28 @@ export function PlayerSection() {
         <span className="song-title">{getSongTitle(activeSong)}</span>
       </h2>
 
-      <GlobalControls
-        onApply={handleApply}
-        onReset={handleReset}
-        onPrecalculate={handlePrecalculate}
-        isPrecalculating={isPrecalculating}
-      />
+      <div className="controls-section">
+        <div
+          className="collapsible-header"
+          onClick={() => setControlsCollapsed(!controlsCollapsed)}
+        >
+          <h3 className="sub-section-heading">Pitch &amp; Tempo</h3>
+          <button
+            className="collapsible-toggle"
+            aria-label={controlsCollapsed ? "Expand pitch and tempo" : "Collapse pitch and tempo"}
+          >
+            <span className={`chevron${controlsCollapsed ? " collapsed" : ""}`}>▼</span>
+          </button>
+        </div>
+        <div className={`collapsible-body ${controlsCollapsed ? "collapsed" : "expanded"}`}>
+          <GlobalControls
+            onApply={handleApply}
+            onReset={handleReset}
+            onPrecalculate={handlePrecalculate}
+            isPrecalculating={isPrecalculating}
+          />
+        </div>
+      </div>
 
       {loadError && (
         <p className="load-error" role="alert">

--- a/frontend/src/components/VersionsPicker.tsx
+++ b/frontend/src/components/VersionsPicker.tsx
@@ -22,6 +22,7 @@ export function VersionsPicker({ onSelectVersion, onSelectOriginal }: Props) {
   // Track which version keys are cached in the SW stem cache.
   const [cachedKeys, setCachedKeys] = useState<Set<string>>(new Set());
   const [isOriginalCached, setIsOriginalCached] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
     if (!activeSong || activeSong.stems.length === 0) {
@@ -100,18 +101,10 @@ export function VersionsPicker({ onSelectVersion, onSelectOriginal }: Props) {
     </li>
   );
 
-  if (versions.length === 0) {
-    return (
-      <div className="versions-section" id="versions-section">
-        <h3 className="sub-section-heading">Song Versions</h3>
-        <ul className="versions-list">{originalBubble}</ul>
-      </div>
-    );
-  }
-
-  return (
-    <div className="versions-section" id="versions-section">
-      <h3 className="sub-section-heading">Song Versions</h3>
+  const list =
+    versions.length === 0 ? (
+      <ul className="versions-list">{originalBubble}</ul>
+    ) : (
       <ul className="versions-list" id="versions-list">
         {originalBubble}
         {versions.map((ver) => {
@@ -174,6 +167,25 @@ export function VersionsPicker({ onSelectVersion, onSelectOriginal }: Props) {
           );
         })}
       </ul>
+    );
+
+  return (
+    <div className="versions-section" id="versions-section">
+      <div
+        className="collapsible-header"
+        onClick={() => setCollapsed(!collapsed)}
+      >
+        <h3 className="sub-section-heading">Song Versions</h3>
+        <button
+          className="collapsible-toggle"
+          aria-label={collapsed ? "Expand song versions" : "Collapse song versions"}
+        >
+          <span className={`chevron${collapsed ? " collapsed" : ""}`}>▼</span>
+        </button>
+      </div>
+      <div className={`collapsible-body ${collapsed ? "collapsed" : "expanded"}`}>
+        {list}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/VersionsPicker.tsx
+++ b/frontend/src/components/VersionsPicker.tsx
@@ -101,11 +101,17 @@ export function VersionsPicker({ onSelectVersion, onSelectOriginal }: Props) {
   );
 
   if (versions.length === 0) {
-    return <ul className="versions-list">{originalBubble}</ul>;
+    return (
+      <div className="versions-section" id="versions-section">
+        <h3 className="sub-section-heading">Song Versions</h3>
+        <ul className="versions-list">{originalBubble}</ul>
+      </div>
+    );
   }
 
   return (
     <div className="versions-section" id="versions-section">
+      <h3 className="sub-section-heading">Song Versions</h3>
       <ul className="versions-list" id="versions-list">
         {originalBubble}
         {versions.map((ver) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -454,11 +454,20 @@ a:hover { text-decoration: underline; }
 }
 .playback-buttons {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
+  flex-wrap: nowrap;   /* always a single row */
+  gap: 0.3rem;
 }
-/* On small screens: 2 buttons per row (3 rows for 6 buttons) */
-.playback-buttons .btn { flex: 1 1 calc(50% - 0.325rem); }
+/* Mobile: equal-width, compact so all 7 fit on the narrowest screens */
+.playback-buttons .btn {
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0.5rem 0.15rem;
+}
+/* btn-lg overrides base padding; pull it back to compact inside playback-buttons */
+.playback-buttons .btn-lg {
+  padding: 0.5rem 0.15rem;
+  font-size: 0.9rem;
+}
 .seek-row { display: flex; align-items: center; gap: 0.65rem; }
 .seek-slider-wrapper {
   position: relative;
@@ -566,8 +575,9 @@ a:hover { text-decoration: underline; }
 }
 
 @media (min-width: 600px) {
-  .playback-buttons { flex-wrap: nowrap; }
-  .playback-buttons .btn { flex: 0 0 auto; }
+  .playback-buttons { gap: 0.65rem; }
+  .playback-buttons .btn { flex: 0 0 auto; padding: 0.5rem 1rem; }
+  .playback-buttons .btn-lg { padding: 0.75rem 1.75rem; font-size: 1rem; }
 }
 
 /* ---------- Loop interval history ---------- */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -327,14 +327,6 @@ a:hover { text-decoration: underline; }
   padding-bottom: 1rem;
   border-bottom: 1px solid var(--color-border);
 }
-.versions-section h3 {
-  font-size: 0.88rem;
-  color: var(--color-muted);
-  font-weight: 600;
-  margin-bottom: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
 .versions-list {
   list-style: none;
   display: flex;
@@ -598,11 +590,9 @@ a:hover { text-decoration: underline; }
   gap: 0.3rem;
 }
 .loop-history-title {
-  font-size: 0.75rem;
-  font-weight: bold;
+  font-size: 0.9rem;
+  font-weight: 600;
   color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
 .loop-history-item {
   display: flex;

--- a/frontend/src/test/components/PlaybackBar.test.tsx
+++ b/frontend/src/test/components/PlaybackBar.test.tsx
@@ -37,6 +37,11 @@ const defaultProps = {
   onLoopAdjustA: vi.fn(),
   onLoopAdjustB: vi.fn(),
   onLoopShift: vi.fn(),
+  onAddCurrentToHistory: vi.fn(),
+  onRemoveCurrentInterval: vi.fn(),
+  onRestoreHistoryItem: vi.fn(),
+  onRemoveHistoryItem: vi.fn(),
+  onClearLoopHistory: vi.fn(),
 };
 
 describe("PlaybackBar", () => {
@@ -220,5 +225,49 @@ describe("PlaybackBar", () => {
     render(<PlaybackBar {...defaultProps} onLoopShift={onLoopShift} />);
     fireEvent.click(document.querySelector("#loop-shift-btn")!);
     expect(onLoopShift).toHaveBeenCalledTimes(1);
+  });
+
+  describe("AB Loop collapsible header", () => {
+    it("renders a collapsible-header wrapping the AB Loop title", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      expect(document.querySelector(".collapsible-header")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "AB Loop" })).toBeInTheDocument();
+    });
+
+    it("AB loop body is expanded by default", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      expect(document.querySelector(".collapsible-body.expanded")).toBeInTheDocument();
+    });
+
+    it("clicking the AB Loop collapsible header collapses the loop body", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      fireEvent.click(document.querySelector(".collapsible-header")!);
+      expect(document.querySelector(".collapsible-body.collapsed")).toBeInTheDocument();
+    });
+
+    it("clicking the AB Loop collapsible header again expands the loop body", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      const header = document.querySelector(".collapsible-header")!;
+      fireEvent.click(header);
+      fireEvent.click(header);
+      expect(document.querySelector(".collapsible-body.expanded")).toBeInTheDocument();
+    });
+
+    it("toggle button has aria-label 'Collapse AB loop' when expanded", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      expect(document.querySelector(".collapsible-toggle")).toHaveAttribute(
+        "aria-label",
+        "Collapse AB loop",
+      );
+    });
+
+    it("toggle button has aria-label 'Expand AB loop' when collapsed", () => {
+      render(<PlaybackBar {...defaultProps} />);
+      fireEvent.click(document.querySelector(".collapsible-header")!);
+      expect(document.querySelector(".collapsible-toggle")).toHaveAttribute(
+        "aria-label",
+        "Expand AB loop",
+      );
+    });
   });
 });

--- a/frontend/src/test/components/VersionsPicker.test.tsx
+++ b/frontend/src/test/components/VersionsPicker.test.tsx
@@ -57,9 +57,9 @@ beforeEach(() => {
 });
 
 describe("VersionsPicker", () => {
-  it("renders nothing when versions list is empty", () => {
+  it("renders the versions section even when versions list is empty", () => {
     render(<VersionsPicker onSelectVersion={vi.fn()} />);
-    expect(document.querySelector("#versions-section")).not.toBeInTheDocument();
+    expect(document.querySelector("#versions-section")).toBeInTheDocument();
   });
 
   it("renders an Original bubble even when versions list is empty", () => {

--- a/frontend/src/test/components/VersionsPicker.test.tsx
+++ b/frontend/src/test/components/VersionsPicker.test.tsx
@@ -284,6 +284,49 @@ describe("VersionsPicker", () => {
     });
   });
 
+  describe("collapsible header", () => {
+    it("renders a collapsible-header wrapping the Song Versions title", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      expect(document.querySelector(".collapsible-header")).toBeInTheDocument();
+    });
+
+    it("versions body is expanded by default", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      expect(document.querySelector(".collapsible-body.expanded")).toBeInTheDocument();
+    });
+
+    it("clicking the collapsible header collapses the versions body", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      fireEvent.click(document.querySelector(".collapsible-header")!);
+      expect(document.querySelector(".collapsible-body.collapsed")).toBeInTheDocument();
+    });
+
+    it("clicking the collapsible header again expands the versions body", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      const header = document.querySelector(".collapsible-header")!;
+      fireEvent.click(header);
+      fireEvent.click(header);
+      expect(document.querySelector(".collapsible-body.expanded")).toBeInTheDocument();
+    });
+
+    it("toggle button has aria-label 'Collapse song versions' when expanded", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      expect(document.querySelector(".collapsible-toggle")).toHaveAttribute(
+        "aria-label",
+        "Collapse song versions",
+      );
+    });
+
+    it("toggle button has aria-label 'Expand song versions' when collapsed", () => {
+      render(<VersionsPicker onSelectVersion={vi.fn()} />);
+      fireEvent.click(document.querySelector(".collapsible-header")!);
+      expect(document.querySelector(".collapsible-toggle")).toHaveAttribute(
+        "aria-label",
+        "Expand song versions",
+      );
+    });
+  });
+
   describe("Original bubble cache indicator", () => {
     it("adds version-cached class to Original bubble when original audio is cached", async () => {
       const audioCache = await import("../../audio/audioCache");


### PR DESCRIPTION
This pull request introduces a new pre-commit hook to enforce frontend and backend checks before every commit, updates documentation to reflect these changes, and adds a UI improvement to the player controls section. The most significant changes are grouped below.

**Development workflow improvements:**

* Added a `.githooks/pre-commit` script that runs frontend tests, build (type-check), ruff, mypy, and pytest before each commit to ensure code quality.
* Updated `README.md` to instruct developers to activate the pre-commit hook, clarifying that these checks are now automated on commit.
* Revised `AGENTS.md` to document that the pre-commit hook enforces all required checks, simplifying the manual testing instructions.

**Frontend user interface enhancements:**

* In `PlayerSection.tsx`, added a collapsible "Pitch & Tempo" controls section, allowing users to expand or collapse these controls for a cleaner UI. [[1]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR112) [[2]](diffhunk://#diff-2add99d5b7f7b41aec304393b78814601714889956a6119da0587706ebf391dfR840-R861)## Summary

<!-- One-sentence description of what this PR does. -->

## Motivation / linked issue

<!-- Why is this change needed? Link any related issue: Closes #123 -->

## Changes

<!-- Bullet-point list of what was changed and why. -->
- 

## Testing

<!-- How was this tested? Check all that apply. -->
- [ ] New unit/integration tests added in `backend/tests/`
- [ ] Existing tests pass locally (`PYTHONPATH=. pytest backend/tests/ -v`)
- [ ] Manual testing performed (describe steps below)

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, …)
- [ ] Code passes `ruff check backend/` and `ruff format --check backend/`
- [ ] Code passes `mypy backend/app/ --ignore-missing-imports`
- [ ] New public functions/classes have type hints
- [ ] Documentation updated if needed (README, docstrings, API reference)
